### PR TITLE
Add support for multiple task webhook URLs

### DIFF
--- a/crates/index-scheduler/src/insta_snapshot.rs
+++ b/crates/index-scheduler/src/insta_snapshot.rs
@@ -28,7 +28,7 @@ pub fn snapshot_index_scheduler(scheduler: &IndexScheduler) -> String {
 
         index_mapper,
         features: _,
-        webhook_url: _,
+        webhook_urls: _,
         webhook_authorization_header: _,
         test_breakpoint_sdr: _,
         planned_failures: _,

--- a/crates/index-scheduler/src/test_utils.rs
+++ b/crates/index-scheduler/src/test_utils.rs
@@ -98,7 +98,7 @@ impl IndexScheduler {
             indexes_path: tempdir.path().join("indexes"),
             snapshots_path: tempdir.path().join("snapshots"),
             dumps_path: tempdir.path().join("dumps"),
-            webhook_url: None,
+            webhook_urls: Vec::new(),
             webhook_authorization_header: None,
             task_db_size: 1000 * 1000 * 10, // 10 MB, we don't use MiB on purpose.
             index_base_map_size: 1000 * 1000, // 1 MB, we don't use MiB on purpose.

--- a/crates/meilisearch/src/analytics/segment_analytics.rs
+++ b/crates/meilisearch/src/analytics/segment_analytics.rs
@@ -345,7 +345,7 @@ impl Infos {
             experimental_max_number_of_batched_tasks,
             experimental_limit_batched_tasks_total_size:
                 experimental_limit_batched_tasks_total_size.into(),
-            task_queue_webhook: task_webhook_url.is_some(),
+            task_queue_webhook: !task_webhook_url.is_empty(),
             task_webhook_authorization_header: task_webhook_authorization_header.is_some(),
             log_level: log_level.to_string(),
             max_indexing_memory,

--- a/crates/meilisearch/src/lib.rs
+++ b/crates/meilisearch/src/lib.rs
@@ -221,7 +221,7 @@ pub fn setup_meilisearch(opt: &Opt) -> anyhow::Result<(Arc<IndexScheduler>, Arc<
         indexes_path: opt.db_path.join("indexes"),
         snapshots_path: opt.snapshot_dir.clone(),
         dumps_path: opt.dump_dir.clone(),
-        webhook_url: opt.task_webhook_url.as_ref().map(|url| url.to_string()),
+        webhook_urls: opt.task_webhook_url.iter().map(|url| url.to_string()).collect(),
         webhook_authorization_header: opt.task_webhook_authorization_header.clone(),
         task_db_size: opt.max_task_db_size.as_u64() as usize,
         index_base_map_size: opt.max_index_size.as_u64() as usize,

--- a/crates/meilisearch/src/option.rs
+++ b/crates/meilisearch/src/option.rs
@@ -205,7 +205,7 @@ pub struct Opt {
 
     /// Called whenever a task finishes so a third party can be notified.
     /// Multiple URLs can be specified separated by a space or by repeating the option.
-    #[clap(long, env = MEILI_TASK_WEBHOOK_URL, value_delimiter = ' ')]
+    #[clap(long, env = MEILI_TASK_WEBHOOK_URL, value_delimiter = ',')]
     pub task_webhook_url: Vec<Url>,
 
     /// The Authorization header to send on the webhook URL whenever

--- a/crates/meilisearch/src/option.rs
+++ b/crates/meilisearch/src/option.rs
@@ -204,8 +204,9 @@ pub struct Opt {
     pub env: String,
 
     /// Called whenever a task finishes so a third party can be notified.
-    #[clap(long, env = MEILI_TASK_WEBHOOK_URL)]
-    pub task_webhook_url: Option<Url>,
+    /// Multiple URLs can be specified separated by a space or by repeating the option.
+    #[clap(long, env = MEILI_TASK_WEBHOOK_URL, value_delimiter = ' ')]
+    pub task_webhook_url: Vec<Url>,
 
     /// The Authorization header to send on the webhook URL whenever
     /// a task finishes so a third party can be notified.
@@ -579,8 +580,10 @@ impl Opt {
             export_to_env_if_not_present(MEILI_MASTER_KEY, master_key);
         }
         export_to_env_if_not_present(MEILI_ENV, env);
-        if let Some(task_webhook_url) = task_webhook_url {
-            export_to_env_if_not_present(MEILI_TASK_WEBHOOK_URL, task_webhook_url.to_string());
+        if !task_webhook_url.is_empty() {
+            let urls =
+                task_webhook_url.into_iter().map(|u| u.to_string()).collect::<Vec<_>>().join(" ");
+            export_to_env_if_not_present(MEILI_TASK_WEBHOOK_URL, urls);
         }
         if let Some(task_webhook_authorization_header) = task_webhook_authorization_header {
             export_to_env_if_not_present(


### PR DESCRIPTION
## Summary
- allow specifying multiple webhook URLs via `MEILI_TASK_WEBHOOK_URL`
- propagate the list of URLs to index scheduler
- send task updates to each configured endpoint
- test multi‑webhook behaviour

## Testing
- `cargo test --locked test_basic_webhook -- --nocapture` *(fails: Failed to download a valid file from all sources)*