### PR TITLE
Add task websocket endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,29 @@
 version = 4
 
 [[package]]
+name = "actix"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de7fa236829ba0841304542f7614c42b80fca007455315c45c785ccfa873a85b"
+dependencies = [
+ "actix-rt",
+ "bitflags 2.9.1",
+ "bytes",
+ "crossbeam-channel",
+ "futures-core",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "actix-codec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -206,6 +229,24 @@ dependencies = [
  "time",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "actix-web-actors"
+version = "4.3.1+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98c5300b38fd004fe7d2a964f9a90813fdbe8a81fed500587e78b1b71c6f980"
+dependencies = [
+ "actix",
+ "actix-codec",
+ "actix-http",
+ "actix-web",
+ "bytes",
+ "bytestring",
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -3027,6 +3068,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.12",
  "time",
+ "tokio",
  "tracing",
  "ureq",
  "uuid",
@@ -3742,6 +3784,7 @@ dependencies = [
  "actix-rt",
  "actix-utils",
  "actix-web",
+ "actix-web-actors",
  "actix-web-lab",
  "anyhow",
  "async-openai",

--- a/crates/index-scheduler/Cargo.toml
+++ b/crates/index-scheduler/Cargo.toml
@@ -45,6 +45,7 @@ tracing = "0.1.41"
 ureq = "2.12.1"
 uuid = { version = "1.17.0", features = ["serde", "v4"] }
 backoff = "0.4.0"
+tokio = { version = "1.45.1", features = ["sync"] }
 
 [dev-dependencies]
 big_s = "1.0.2"

--- a/crates/index-scheduler/src/test_utils.rs
+++ b/crates/index-scheduler/src/test_utils.rs
@@ -115,6 +115,7 @@ impl IndexScheduler {
             auto_upgrade: true, // Don't cost much and will ensure the happy path works
             embedding_cache_cap: 10,
             experimental_no_snapshot_compaction: false,
+            task_sender: None,
         };
         let version = configuration(&mut options).unwrap_or({
             (versioning::VERSION_MAJOR, versioning::VERSION_MINOR, versioning::VERSION_PATCH)

--- a/crates/meilisearch/Cargo.toml
+++ b/crates/meilisearch/Cargo.toml
@@ -89,6 +89,7 @@ time = { version = "0.3.41", features = [
     "macros",
 ] }
 tokio = { version = "1.45.1", features = ["full"] }
+actix-web-actors = "4.3.0"
 toml = "0.8.23"
 uuid = { version = "1.17.0", features = ["serde", "v4"] }
 serde_urlencoded = "0.7.1"

--- a/crates/meilisearch/src/routes/mod.rs
+++ b/crates/meilisearch/src/routes/mod.rs
@@ -65,6 +65,7 @@ mod multi_search;
 mod multi_search_analytics;
 pub mod network;
 mod open_api_utils;
+mod tasks_socket;
 mod snapshot;
 mod swap_indexes;
 pub mod tasks;

--- a/crates/meilisearch/src/routes/tasks.rs
+++ b/crates/meilisearch/src/routes/tasks.rs
@@ -18,6 +18,7 @@ use serde::Serialize;
 use time::format_description::well_known::Rfc3339;
 use time::macros::format_description;
 use time::{Date, Duration, OffsetDateTime, Time};
+use crate::routes::tasks_socket;
 use tokio::io::AsyncReadExt;
 use tokio::task;
 use utoipa::{IntoParams, OpenApi, ToSchema};
@@ -51,7 +52,8 @@ pub fn configure(cfg: &mut web::ServiceConfig) {
     .service(
         web::resource("/{task_id}/documents")
             .route(web::get().to(SeqHandler(get_task_documents_file))),
-    );
+    )
+    .service(web::resource("/stream").route(web::get().to(tasks_socket::task_socket)));
 }
 
 #[derive(Debug, Deserr, IntoParams)]

--- a/crates/meilisearch/src/routes/tasks_socket.rs
+++ b/crates/meilisearch/src/routes/tasks_socket.rs
@@ -1,0 +1,42 @@
+use actix::{Actor, StreamHandler};
+use actix_web::{web, HttpRequest, HttpResponse, Error};
+use actix_web_actors::ws;
+use futures_util::StreamExt;
+use index_scheduler::IndexScheduler;
+use tokio::sync::broadcast;
+
+pub async fn task_socket(
+    req: HttpRequest,
+    stream: web::Payload,
+    index_scheduler: web::Data<IndexScheduler>,
+) -> Result<HttpResponse, Error> {
+    let receiver = index_scheduler
+        .task_sender
+        .as_ref()
+        .map(|s| s.subscribe());
+    ws::start(TaskWs { receiver }, &req, stream)
+}
+
+struct TaskWs {
+    receiver: Option<broadcast::Receiver<Vec<u8>>>,
+}
+
+impl Actor for TaskWs {
+    type Context = ws::WebsocketContext<Self>;
+
+    fn started(&mut self, ctx: &mut Self::Context) {
+        if let Some(mut rx) = self.receiver.take() {
+            ctx.add_stream(async_stream::stream! {
+                while let Ok(msg) = rx.recv().await {
+                    yield ws::Message::Binary(msg);
+                }
+            });
+        }
+    }
+}
+
+impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for TaskWs {
+    fn handle(&mut self, _item: Result<ws::Message, ws::ProtocolError>, _ctx: &mut Self::Context) {
+        // ignore incoming messages
+    }
+}


### PR DESCRIPTION
## Summary
- support a broadcast channel for task updates
- expose sender via `IndexSchedulerOptions`
- create `/tasks/stream` websocket endpoint

## Testing
- `cargo check -p meilisearch` *(failed: build timed out)*

------
https://chatgpt.com/codex/tasks/task_b_6888981130ac8326bb31be214db23bc5