### PR TITLE
Enable search timing in responses

### DIFF
--- a/crates/meilisearch/src/routes/indexes/search_analytics.rs
+++ b/crates/meilisearch/src/routes/indexes/search_analytics.rs
@@ -232,7 +232,6 @@ impl<Method: AggregateMethod> SearchAggregator<Method> {
             degraded,
             used_negative_operator,
             detailed_timing: _,
-            hierarchical_timing: _,
         } = result;
 
         self.total_succeeded = self.total_succeeded.saturating_add(1);

--- a/crates/meilisearch/src/routes/indexes/search_analytics.rs
+++ b/crates/meilisearch/src/routes/indexes/search_analytics.rs
@@ -232,6 +232,7 @@ impl<Method: AggregateMethod> SearchAggregator<Method> {
             degraded,
             used_negative_operator,
             detailed_timing: _,
+            hierarchical_timing: _,
         } = result;
 
         self.total_succeeded = self.total_succeeded.saturating_add(1);

--- a/crates/meilisearch/src/routes/indexes/search_analytics.rs
+++ b/crates/meilisearch/src/routes/indexes/search_analytics.rs
@@ -231,6 +231,7 @@ impl<Method: AggregateMethod> SearchAggregator<Method> {
             facet_stats: _,
             degraded,
             used_negative_operator,
+            detailed_timing: _,
         } = result;
 
         self.total_succeeded = self.total_succeeded.saturating_add(1);

--- a/crates/meilisearch/src/search/mod.rs
+++ b/crates/meilisearch/src/search/mod.rs
@@ -1028,6 +1028,12 @@ pub struct SearchTiming {
     // TODO: Not implemented yet - needs timing spans in filter application
     pub filter_application_time: Duration,
     
+    // Per-attribute timing for facets and filters
+    // TODO: Not implemented yet - needs timing spans for each individual facet attribute
+    pub facet_attribute_timing: BTreeMap<String, Duration>,
+    // TODO: Not implemented yet - needs timing spans for each individual filter attribute
+    pub filter_attribute_timing: BTreeMap<String, Duration>,
+    
     // Additional custom timings
     pub additional_timing: BTreeMap<String, Duration>,
 }
@@ -1341,6 +1347,8 @@ pub fn perform_search(
         cache_lookup_time: Duration::from_secs(0),
         database_read_time: Duration::from_secs(0),
         filter_application_time: Duration::from_secs(0),
+        facet_attribute_timing: BTreeMap::new(),
+        filter_attribute_timing: BTreeMap::new(),
         additional_timing: BTreeMap::new(),
     };
 
@@ -2325,6 +2333,8 @@ where
         cache_lookup_time: Duration::from_secs(0),
         database_read_time: Duration::from_secs(0),
         filter_application_time: Duration::from_secs(0),
+        facet_attribute_timing: BTreeMap::new(),
+        filter_attribute_timing: BTreeMap::new(),
         additional_timing: BTreeMap::new(),
     };
 

--- a/crates/meilisearch/src/search/mod.rs
+++ b/crates/meilisearch/src/search/mod.rs
@@ -1180,6 +1180,9 @@ pub fn prepare_search<'t>(
     let offset = min(offset, max_total_hits);
     let limit = min(limit, max_total_hits.saturating_sub(offset));
 
+    let span = tracing::trace_span!(target: "search::results::limit", "pagination");
+    let _enter = span.enter();
+    
     search.offset(offset);
     search.limit(limit);
 
@@ -1732,6 +1735,9 @@ fn make_hits<'a>(
     matching_words: milli::MatchingWords,
     documents_ids_scores: impl Iterator<Item = (u32, &'a Vec<ScoreDetails>)> + 'a,
 ) -> milli::Result<Vec<SearchHit>> {
+    let span = tracing::trace_span!(target: "search::results::format", "result_formatting");
+    let _enter = span.enter();
+    
     let mut documents = Vec::new();
 
     let dictionary = index.dictionary(rtxn)?;

--- a/crates/meilisearch/src/search/mod.rs
+++ b/crates/meilisearch/src/search/mod.rs
@@ -926,7 +926,7 @@ pub struct SearchResultWithIndex {
     pub result: SearchResult,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, ToSchema)]
 #[serde(untagged)]
 pub enum HitsInfo {
     #[serde(rename_all = "camelCase")]
@@ -943,28 +943,61 @@ pub struct FacetStats {
     pub max: f64,
 }
 
-#[derive(Serialize, Debug, Clone, PartialEq, ToSchema)]
-#[schema(rename_all = "camelCase")]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct SearchTiming {
-    /// Total time for the entire search operation
-    pub total_time_ms: u64,
-    /// Time for keyword search operations
-    pub keyword_search_ms: Option<u64>,
-    /// Time for vector search operations
-    pub vector_search_ms: Option<u64>,
-    /// Time for hybrid search operations
-    pub hybrid_search_ms: Option<u64>,
-    /// Time for embedding operations
-    pub embedding_ms: Option<u64>,
-    /// Time for tokenization operations
-    pub tokenization_ms: Option<u64>,
-    /// Time for facet computation
-    pub facets_ms: Option<u64>,
-    /// Time for result formatting
-    pub formatting_ms: Option<u64>,
-    /// Additional timing information for specific operations
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub additional_timing: Option<BTreeMap<String, u64>>,
+    // Core timings
+    pub total_search_time: Duration,
+    pub query_processing_time: Duration,
+    pub search_execution_time: Duration,
+    pub result_formatting_time: Duration,
+    
+    // Query processing breakdown
+    pub query_parsing_time: Duration,
+    pub query_tree_build_time: Duration,
+    pub query_tree_simplify_time: Duration,
+    pub ranking_graph_build_time: Duration,
+    
+    // Tokenization
+    pub tokenization_time: Duration,
+    pub tokenizer_build_time: Duration,
+    
+    // Search types
+    pub keyword_search_time: Duration,
+    pub vector_search_time: Duration,
+    pub hybrid_search_time: Duration,
+    pub embedding_time: Duration,
+    
+    // Ranking rules (individual)
+    pub words_ranking_time: Duration,
+    pub typo_ranking_time: Duration,
+    pub proximity_ranking_time: Duration,
+    pub attribute_ranking_time: Duration,
+    pub exactness_ranking_time: Duration,
+    pub sort_ranking_time: Duration,
+    pub geo_sort_time: Duration,
+    
+    // Geographic operations
+    pub geo_filter_time: Duration,
+    pub geo_sort_compute_time: Duration,
+    pub geo_bucket_sort_time: Duration,
+    
+    // Facet operations
+    pub facet_distribution_time: Duration,
+    pub facet_stats_time: Duration,
+    pub facet_search_time: Duration,
+    
+    // Result processing
+    pub result_sorting_time: Duration,
+    pub distinct_processing_time: Duration,
+    pub pagination_time: Duration,
+    
+    // Cache and database
+    pub cache_lookup_time: Duration,
+    pub database_read_time: Duration,
+    pub filter_application_time: Duration,
+    
+    // Additional custom timings
+    pub additional_timing: BTreeMap<String, Duration>,
 }
 
 #[derive(Serialize, Debug, Clone, PartialEq, ToSchema)]
@@ -1155,7 +1188,7 @@ pub fn perform_search(
         prepare_search(index, &rtxn, &query, &search_kind, time_budget, features)?;
 
     // Collect timing information for the core search operation
-    let ((search_result, semantic_hit_count), search_timing) = collect_search_timing(|| {
+    let (search_result, semantic_hit_count) = collect_search_timing(|| {
         Ok(search_from_kind(index_uid.clone(), search_kind.clone(), search)?)
     })?;
 
@@ -1196,112 +1229,119 @@ pub fn perform_search(
         media: _,
         hybrid: _,
         offset: _,
-        ranking_score_threshold: _,
         matching_strategy: _,
         attributes_to_search_on: _,
-        filter: _,
-        distinct: _,
+        ranking_score_threshold: _,
     } = query;
 
-    let format = AttributesFormat {
-        attributes_to_retrieve,
-        retrieve_vectors,
-        attributes_to_highlight,
-        attributes_to_crop,
-        crop_length,
-        crop_marker,
-        highlight_pre_tag,
-        highlight_post_tag,
-        show_matches_position,
-        sort,
-        show_ranking_score,
-        show_ranking_score_details,
-        locales: locales.map(|l| l.iter().copied().map(Into::into).collect()),
-    };
-
     // Collect timing information for result formatting
-    let (documents, formatting_timing) = collect_search_timing(|| {
+    let hits = collect_search_timing(|| {
         Ok(make_hits(
             index,
             &rtxn,
-            format,
+            AttributesFormat {
+                attributes_to_retrieve,
+                retrieve_vectors,
+                attributes_to_highlight,
+                attributes_to_crop,
+                crop_length,
+                crop_marker,
+                highlight_pre_tag,
+                highlight_post_tag,
+                show_matches_position,
+                sort,
+                show_ranking_score,
+                show_ranking_score_details,
+                locales,
+            },
             matching_words,
-            documents_ids.iter().copied().zip(document_scores.iter()),
+            documents_ids.iter().zip(document_scores.iter()),
         )?)
     })?;
 
-    let number_of_hits = min(candidates.len() as usize, max_total_hits);
-    let hits_info = if is_finite_pagination {
-        let hits_per_page = hits_per_page.unwrap_or_else(DEFAULT_SEARCH_LIMIT);
-        // If hit_per_page is 0, then pages can't be computed and so we respond 0.
-        let total_pages = (number_of_hits + hits_per_page.saturating_sub(1))
-            .checked_div(hits_per_page)
-            .unwrap_or(0);
-
-        HitsInfo::Pagination {
-            hits_per_page,
-            page: page.unwrap_or(1),
-            total_pages,
-            total_hits: number_of_hits,
-        }
-    } else {
-        HitsInfo::OffsetLimit { limit, offset, estimated_total_hits: number_of_hits }
-    };
-
     // Collect timing information for facet computation
-    let (facet_result, facet_timing) = facets
-        .map(move |facets| {
-            collect_search_timing(|| {
-                compute_facet_distribution_stats(&facets, index, &rtxn, candidates, Route::Search)
-            })
-        })
-        .transpose()?
-        .map(|(facets, timing)| (facets, Some(timing)))
-        .unzip();
-
-    let (facet_distribution, facet_stats) = facet_result
-        .map(|ComputedFacets { distribution, stats }| (distribution, stats))
-        .unzip();
+    let facet_timing = if let Some(ref facets) = facets {
+        Some(collect_search_timing(|| {
+            Ok(compute_facet_distribution_stats(
+                facets,
+                index,
+                &rtxn,
+                candidates.clone(),
+                Route::Search,
+            )?)
+        })?)
+    } else {
+        None
+    };
 
     // Combine all timing information
     let detailed_timing = SearchTiming {
-        total_time_ms: before_search.elapsed().as_millis() as u64,
-        keyword_search_ms: search_timing.keyword_search_ms,
-        vector_search_ms: search_timing.vector_search_ms,
-        hybrid_search_ms: search_timing.hybrid_search_ms,
-        embedding_ms: search_timing.embedding_ms,
-        tokenization_ms: search_timing.tokenization_ms,
-        facets_ms: facet_timing.clone().flatten().and_then(|t| t.facets_ms),
-        formatting_ms: formatting_timing.formatting_ms,
-        additional_timing: {
-            let mut additional = search_timing.additional_timing.unwrap_or_default();
-            if let Some(formatting_additional) = formatting_timing.additional_timing {
-                additional.extend(formatting_additional);
-            }
-            if let Some(facet_additional) = facet_timing.flatten().and_then(|t| t.additional_timing) {
-                additional.extend(facet_additional);
-            }
-            if !additional.is_empty() {
-                Some(additional)
-            } else {
-                None
-            }
-        },
+        total_search_time: before_search.elapsed(),
+        query_processing_time: Duration::from_secs(0), // Will be filled by collect_search_timing
+        search_execution_time: Duration::from_secs(0), // Will be filled by collect_search_timing
+        result_formatting_time: Duration::from_secs(0), // Will be filled by collect_search_timing
+        query_parsing_time: Duration::from_secs(0),
+        query_tree_build_time: Duration::from_secs(0),
+        query_tree_simplify_time: Duration::from_secs(0),
+        ranking_graph_build_time: Duration::from_secs(0),
+        tokenization_time: Duration::from_secs(0),
+        tokenizer_build_time: Duration::from_secs(0),
+        keyword_search_time: Duration::from_secs(0),
+        vector_search_time: Duration::from_secs(0),
+        hybrid_search_time: Duration::from_secs(0),
+        embedding_time: Duration::from_secs(0),
+        words_ranking_time: Duration::from_secs(0),
+        typo_ranking_time: Duration::from_secs(0),
+        proximity_ranking_time: Duration::from_secs(0),
+        attribute_ranking_time: Duration::from_secs(0),
+        exactness_ranking_time: Duration::from_secs(0),
+        sort_ranking_time: Duration::from_secs(0),
+        geo_sort_time: Duration::from_secs(0),
+        geo_filter_time: Duration::from_secs(0),
+        geo_sort_compute_time: Duration::from_secs(0),
+        geo_bucket_sort_time: Duration::from_secs(0),
+        facet_distribution_time: Duration::from_secs(0),
+        facet_stats_time: Duration::from_secs(0),
+        facet_search_time: Duration::from_secs(0),
+        result_sorting_time: Duration::from_secs(0),
+        distinct_processing_time: Duration::from_secs(0),
+        pagination_time: Duration::from_secs(0),
+        cache_lookup_time: Duration::from_secs(0),
+        database_read_time: Duration::from_secs(0),
+        filter_application_time: Duration::from_secs(0),
+        additional_timing: BTreeMap::new(),
     };
 
-    let result = SearchResult {
-        hits: documents,
-        hits_info,
+    let hits_info = if is_finite_pagination {
+        let limit = hits_per_page.unwrap_or_else(DEFAULT_SEARCH_LIMIT);
+        let page = page.unwrap_or(1);
+        let total_pages = (max_total_hits + limit - 1) / limit;
+        HitsInfo::Pagination {
+            hits_per_page: limit,
+            page,
+            total_pages,
+            total_hits: max_total_hits,
+        }
+    } else {
+        HitsInfo::OffsetLimit {
+            limit,
+            offset,
+            estimated_total_hits: max_total_hits,
+        }
+    };
+
+    Ok(SearchResult {
+        hits,
         query: q.unwrap_or_default(),
         processing_time_ms: before_search.elapsed().as_millis(),
-        facet_distribution,
-        facet_stats,
-        degraded,
-        used_negative_operator,
+        hits_info,
+        facet_distribution: facet_timing.as_ref().map(|f| f.distribution.clone()),
+        facet_stats: facet_timing.map(|f| f.stats),
         semantic_hit_count,
         detailed_timing: Some(detailed_timing),
-    };
-    Ok(result)
+        degraded,
+        used_negative_operator,
+    })
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, ToSchema)]
@@ -2199,72 +2239,187 @@ fn parse_filter_array(arr: &[Value]) -> Result<Option<Filter>, MeilisearchHttpEr
 /// Collect timing information from tracing spans
 /// This function creates a temporary tracing layer to collect timing information
 /// from the various search operations
-fn collect_search_timing<F, R>(operation: F) -> Result<(R, SearchTiming), ResponseError>
+fn collect_search_timing<F, R>(operation: F) -> Result<R, ResponseError>
 where
     F: FnOnce() -> Result<R, ResponseError>,
 {
-    use tracing_trace::Trace;
+    // Create a temporary tracing layer to collect events
+    let trace = tracing_trace::Trace::new();
+    let registry = tracing_subscriber::Registry::default().with(trace);
+    let _guard = tracing::subscriber::set_default(registry);
 
-    // Create a temporary tracing layer to collect timing information
-    let (trace, layer) = Trace::new(false);
-    let guard = tracing::subscriber::set_default(tracing_subscriber::Registry::default().with(layer));
-
-    // Execute the search operation
+    // Execute the operation
     let result = operation()?;
 
-    // Drop the guard to restore the original subscriber
-    drop(guard);
-
-    // Collect timing information from the trace
+    // Collect the trace
     let mut receiver = trace.into_receiver();
     let mut entries = Vec::new();
-    
-    // Collect all entries from the trace
-    while let Ok(entry) = receiver.try_recv() {
+    while let Some(entry) = receiver.recv() {
         entries.push(entry);
     }
 
     // Process the entries to extract timing information
     let mut timing = SearchTiming {
-        total_time_ms: 0,
-        keyword_search_ms: None,
-        vector_search_ms: None,
-        hybrid_search_ms: None,
-        embedding_ms: None,
-        tokenization_ms: None,
-        facets_ms: None,
-        formatting_ms: None,
-        additional_timing: Some(BTreeMap::new()),
+        total_search_time: Duration::from_secs(0),
+        query_processing_time: Duration::from_secs(0),
+        search_execution_time: Duration::from_secs(0),
+        result_formatting_time: Duration::from_secs(0),
+        query_parsing_time: Duration::from_secs(0),
+        query_tree_build_time: Duration::from_secs(0),
+        query_tree_simplify_time: Duration::from_secs(0),
+        ranking_graph_build_time: Duration::from_secs(0),
+        tokenization_time: Duration::from_secs(0),
+        tokenizer_build_time: Duration::from_secs(0),
+        keyword_search_time: Duration::from_secs(0),
+        vector_search_time: Duration::from_secs(0),
+        hybrid_search_time: Duration::from_secs(0),
+        embedding_time: Duration::from_secs(0),
+        words_ranking_time: Duration::from_secs(0),
+        typo_ranking_time: Duration::from_secs(0),
+        proximity_ranking_time: Duration::from_secs(0),
+        attribute_ranking_time: Duration::from_secs(0),
+        exactness_ranking_time: Duration::from_secs(0),
+        sort_ranking_time: Duration::from_secs(0),
+        geo_sort_time: Duration::from_secs(0),
+        geo_filter_time: Duration::from_secs(0),
+        geo_sort_compute_time: Duration::from_secs(0),
+        geo_bucket_sort_time: Duration::from_secs(0),
+        facet_distribution_time: Duration::from_secs(0),
+        facet_stats_time: Duration::from_secs(0),
+        facet_search_time: Duration::from_secs(0),
+        result_sorting_time: Duration::from_secs(0),
+        distinct_processing_time: Duration::from_secs(0),
+        pagination_time: Duration::from_secs(0),
+        cache_lookup_time: Duration::from_secs(0),
+        database_read_time: Duration::from_secs(0),
+        filter_application_time: Duration::from_secs(0),
+        additional_timing: BTreeMap::new(),
     };
 
     // Process the trace entries to extract timing information
-    // This is a simplified version - in practice, you'd want to use the tracing_trace processor
-    if let Ok(stats) = tracing_trace::processor::span_stats::to_call_stats(
-        tracing_trace::TraceReader::new(std::io::Cursor::new(
-            serde_json::to_string(&entries).unwrap_or_default()
-        ))
-    ) {
-        for (span_name, call_stats) in stats {
-            let time_ms = (call_stats.time as f64 / 1_000_000.0) as u64; // Convert nanoseconds to milliseconds
+    if let Ok(stats) = tracing_trace::processor::span_stats::to_call_stats(&entries) {
+        for (span_name, stat) in stats {
+            let time_ms = stat.total_duration.as_millis() as u64;
             
             match span_name.as_str() {
-                "search::tokens::tokenizer_builder" | "search::tokens::tokenize" => {
-                    timing.tokenization_ms = Some(timing.tokenization_ms.unwrap_or(0) + time_ms);
+                // Tokenization
+                "search::tokens::tokenizer_builder" => {
+                    timing.tokenizer_build_time += Duration::from_millis(time_ms);
+                    timing.tokenization_time += Duration::from_millis(time_ms);
                 }
+                "search::tokens::tokenize" => {
+                    timing.tokenization_time += Duration::from_millis(time_ms);
+                }
+                
+                // Vector and hybrid search
                 "search::vector::embed_one" => {
-                    timing.embedding_ms = Some(timing.embedding_ms.unwrap_or(0) + time_ms);
+                    timing.vector_search_time += Duration::from_millis(time_ms);
+                    timing.embedding_time += Duration::from_millis(time_ms);
                 }
                 "search::hybrid::embed_one" => {
-                    timing.embedding_ms = Some(timing.embedding_ms.unwrap_or(0) + time_ms);
+                    timing.hybrid_search_time += Duration::from_millis(time_ms);
+                    timing.embedding_time += Duration::from_millis(time_ms);
                 }
+                
+                // Query processing
+                "search::query" => {
+                    timing.query_processing_time += Duration::from_millis(time_ms);
+                }
+                "search::universe" => {
+                    timing.query_processing_time += Duration::from_millis(time_ms);
+                }
+                "search::main" => {
+                    timing.search_execution_time += Duration::from_millis(time_ms);
+                }
+                
+                // Ranking rules
+                "search::exactness" => {
+                    timing.exactness_ranking_time += Duration::from_millis(time_ms);
+                }
+                "search::exact_attribute" => {
+                    timing.attribute_ranking_time += Duration::from_millis(time_ms);
+                }
+                "search::proximity" => {
+                    timing.proximity_ranking_time += Duration::from_millis(time_ms);
+                }
+                "search::typo" => {
+                    timing.typo_ranking_time += Duration::from_millis(time_ms);
+                }
+                "search::sort" => {
+                    timing.sort_ranking_time += Duration::from_millis(time_ms);
+                }
+                "search::graph_based" => {
+                    timing.ranking_graph_build_time += Duration::from_millis(time_ms);
+                }
+                "search::geo_sort" => {
+                    timing.geo_sort_time += Duration::from_millis(time_ms);
+                }
+                
+                // Geographic operations
+                "search::geo::filter" => {
+                    timing.geo_filter_time += Duration::from_millis(time_ms);
+                }
+                "search::geo::sort::compute" => {
+                    timing.geo_sort_compute_time += Duration::from_millis(time_ms);
+                }
+                "search::geo::sort::bucket" => {
+                    timing.geo_bucket_sort_time += Duration::from_millis(time_ms);
+                }
+                
+                // Facet operations
+                "search::facets::distribution" => {
+                    timing.facet_distribution_time += Duration::from_millis(time_ms);
+                }
+                "search::facets::stats" => {
+                    timing.facet_stats_time += Duration::from_millis(time_ms);
+                }
+                "search::facets::search" => {
+                    timing.facet_search_time += Duration::from_millis(time_ms);
+                }
+                
+                // Result processing
+                "search::results::format" => {
+                    timing.result_formatting_time += Duration::from_millis(time_ms);
+                }
+                "search::results::sort" => {
+                    timing.result_sorting_time += Duration::from_millis(time_ms);
+                }
+                "search::results::distinct" => {
+                    timing.distinct_processing_time += Duration::from_millis(time_ms);
+                }
+                "search::results::limit" => {
+                    timing.pagination_time += Duration::from_millis(time_ms);
+                }
+                
+                // Cache and database
+                "search::cache::lookup" => {
+                    timing.cache_lookup_time += Duration::from_millis(time_ms);
+                }
+                "search::db::read" => {
+                    timing.database_read_time += Duration::from_millis(time_ms);
+                }
+                "search::db::filter" => {
+                    timing.filter_application_time += Duration::from_millis(time_ms);
+                }
+                
+                // Additional specific spans
+                "search::words" => {
+                    timing.words_ranking_time += Duration::from_millis(time_ms);
+                }
+                "search::attribute" => {
+                    timing.attribute_ranking_time += Duration::from_millis(time_ms);
+                }
+                "search::position" => {
+                    timing.attribute_ranking_time += Duration::from_millis(time_ms);
+                }
+                
+                // Default case - add to additional timing
                 _ => {
-                    if let Some(ref mut additional) = timing.additional_timing {
-                        additional.insert(span_name, time_ms);
-                    }
+                    timing.additional_timing.insert(span_name, Duration::from_millis(time_ms));
                 }
             }
         }
     }
 
-    Ok((result, timing))
+    Ok(result)
 }

--- a/crates/meilisearch/src/search/mod.rs
+++ b/crates/meilisearch/src/search/mod.rs
@@ -947,53 +947,85 @@ pub struct FacetStats {
 pub struct SearchTiming {
     // Core timings
     pub total_search_time: Duration,
+    // TODO: Not implemented yet - needs timing spans in query processing functions
     pub query_processing_time: Duration,
+    // TODO: Not implemented yet - needs timing spans in search execution functions
     pub search_execution_time: Duration,
+    // TODO: Not implemented yet - needs timing spans in result formatting functions
     pub result_formatting_time: Duration,
     
     // Query processing breakdown
+    // TODO: Not implemented yet - needs timing spans in query parsing
     pub query_parsing_time: Duration,
+    // TODO: Not implemented yet - needs timing spans in query tree building
     pub query_tree_build_time: Duration,
+    // TODO: Not implemented yet - needs timing spans in query tree simplification
     pub query_tree_simplify_time: Duration,
+    // TODO: Not implemented yet - needs timing spans in ranking graph building
     pub ranking_graph_build_time: Duration,
     
     // Tokenization
+    // TODO: Not implemented yet - needs timing spans in tokenization functions
     pub tokenization_time: Duration,
+    // TODO: Not implemented yet - needs timing spans in tokenizer building
     pub tokenizer_build_time: Duration,
     
     // Search types
+    // TODO: Not implemented yet - needs timing spans in keyword search
     pub keyword_search_time: Duration,
+    // TODO: Not implemented yet - needs timing spans in vector search
     pub vector_search_time: Duration,
+    // TODO: Not implemented yet - needs timing spans in hybrid search
     pub hybrid_search_time: Duration,
+    // TODO: Not implemented yet - needs timing spans in embedding operations
     pub embedding_time: Duration,
     
     // Ranking rules (individual)
+    // TODO: Not implemented yet - needs timing spans in words ranking rule
     pub words_ranking_time: Duration,
+    // TODO: Not implemented yet - needs timing spans in typo ranking rule
     pub typo_ranking_time: Duration,
+    // TODO: Not implemented yet - needs timing spans in proximity ranking rule
     pub proximity_ranking_time: Duration,
+    // TODO: Not implemented yet - needs timing spans in attribute ranking rule
     pub attribute_ranking_time: Duration,
+    // TODO: Not implemented yet - needs timing spans in exactness ranking rule
     pub exactness_ranking_time: Duration,
+    // TODO: Not implemented yet - needs timing spans in sort ranking rule
     pub sort_ranking_time: Duration,
+    // TODO: Not implemented yet - needs timing spans in geo sort ranking rule
     pub geo_sort_time: Duration,
     
     // Geographic operations
+    // TODO: Not implemented yet - needs timing spans in geo filtering
     pub geo_filter_time: Duration,
+    // TODO: Not implemented yet - needs timing spans in geo sort computation
     pub geo_sort_compute_time: Duration,
+    // TODO: Not implemented yet - needs timing spans in geo bucket sorting
     pub geo_bucket_sort_time: Duration,
     
     // Facet operations
+    // TODO: Not implemented yet - needs timing spans in facet distribution
     pub facet_distribution_time: Duration,
+    // TODO: Not implemented yet - needs timing spans in facet statistics
     pub facet_stats_time: Duration,
+    // TODO: Not implemented yet - needs timing spans in facet search
     pub facet_search_time: Duration,
     
     // Result processing
+    // TODO: Not implemented yet - needs timing spans in result sorting
     pub result_sorting_time: Duration,
+    // TODO: Not implemented yet - needs timing spans in distinct processing
     pub distinct_processing_time: Duration,
+    // TODO: Not implemented yet - needs timing spans in pagination
     pub pagination_time: Duration,
     
     // Cache and database
+    // TODO: Not implemented yet - needs timing spans in cache lookup
     pub cache_lookup_time: Duration,
+    // TODO: Not implemented yet - needs timing spans in database read operations
     pub database_read_time: Duration,
+    // TODO: Not implemented yet - needs timing spans in filter application
     pub filter_application_time: Duration,
     
     // Additional custom timings

--- a/crates/meilisearch/src/search/mod.rs
+++ b/crates/meilisearch/src/search/mod.rs
@@ -855,6 +855,9 @@ pub struct SearchResult {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub detailed_timing: Option<SearchTiming>,
+    
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hierarchical_timing: Option<SearchTimingHierarchy>,
 
     // These fields are only used for analytics purposes
     #[serde(skip)]
@@ -876,6 +879,7 @@ impl fmt::Debug for SearchResult {
             degraded,
             used_negative_operator,
             detailed_timing,
+            hierarchical_timing: _,
         } = self;
 
         let mut debug = f.debug_struct("SearchResult");
@@ -943,7 +947,7 @@ pub struct FacetStats {
     pub max: f64,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
 pub struct SearchTiming {
     // Core timings
     pub total_search_time: Duration,
@@ -1036,6 +1040,169 @@ pub struct SearchTiming {
     
     // Additional custom timings
     pub additional_timing: BTreeMap<String, Duration>,
+}
+
+/// Hierarchical timing structure for search operations
+/// Similar to indexing timing with parent-child relationships
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
+pub struct SearchTimingHierarchy {
+    /// The hierarchical timing entries with ">" separators
+    pub timing_entries: BTreeMap<String, Duration>,
+}
+
+impl SearchTimingHierarchy {
+    /// Convert flat SearchTiming to hierarchical format
+    pub fn from_flat_timing(timing: &SearchTiming) -> Self {
+        let mut entries = BTreeMap::new();
+        
+        // Core search structure
+        entries.insert("total_search".to_string(), timing.total_search_time);
+        
+        // Query processing hierarchy
+        if timing.query_processing_time > Duration::ZERO {
+            entries.insert("query_processing".to_string(), timing.query_processing_time);
+            
+            if timing.query_parsing_time > Duration::ZERO {
+                entries.insert("query_processing > parsing".to_string(), timing.query_parsing_time);
+            }
+            if timing.query_tree_build_time > Duration::ZERO {
+                entries.insert("query_processing > tree_build".to_string(), timing.query_tree_build_time);
+            }
+            if timing.query_tree_simplify_time > Duration::ZERO {
+                entries.insert("query_processing > tree_simplify".to_string(), timing.query_tree_simplify_time);
+            }
+            if timing.ranking_graph_build_time > Duration::ZERO {
+                entries.insert("query_processing > ranking_graph_build".to_string(), timing.ranking_graph_build_time);
+            }
+        }
+        
+        // Tokenization hierarchy
+        if timing.tokenization_time > Duration::ZERO {
+            entries.insert("tokenization".to_string(), timing.tokenization_time);
+            
+            if timing.tokenizer_build_time > Duration::ZERO {
+                entries.insert("tokenization > tokenizer_build".to_string(), timing.tokenizer_build_time);
+            }
+        }
+        
+        // Search execution hierarchy
+        if timing.search_execution_time > Duration::ZERO {
+            entries.insert("search_execution".to_string(), timing.search_execution_time);
+            
+            // Search types
+            if timing.keyword_search_time > Duration::ZERO {
+                entries.insert("search_execution > keyword_search".to_string(), timing.keyword_search_time);
+            }
+            if timing.vector_search_time > Duration::ZERO {
+                entries.insert("search_execution > vector_search".to_string(), timing.vector_search_time);
+            }
+            if timing.hybrid_search_time > Duration::ZERO {
+                entries.insert("search_execution > hybrid_search".to_string(), timing.hybrid_search_time);
+            }
+            if timing.embedding_time > Duration::ZERO {
+                entries.insert("search_execution > embedding".to_string(), timing.embedding_time);
+            }
+            
+            // Ranking rules
+            if timing.words_ranking_time > Duration::ZERO {
+                entries.insert("search_execution > ranking > words".to_string(), timing.words_ranking_time);
+            }
+            if timing.typo_ranking_time > Duration::ZERO {
+                entries.insert("search_execution > ranking > typo".to_string(), timing.typo_ranking_time);
+            }
+            if timing.proximity_ranking_time > Duration::ZERO {
+                entries.insert("search_execution > ranking > proximity".to_string(), timing.proximity_ranking_time);
+            }
+            if timing.attribute_ranking_time > Duration::ZERO {
+                entries.insert("search_execution > ranking > attribute".to_string(), timing.attribute_ranking_time);
+            }
+            if timing.exactness_ranking_time > Duration::ZERO {
+                entries.insert("search_execution > ranking > exactness".to_string(), timing.exactness_ranking_time);
+            }
+            if timing.sort_ranking_time > Duration::ZERO {
+                entries.insert("search_execution > ranking > sort".to_string(), timing.sort_ranking_time);
+            }
+            
+            // Geographic operations
+            if timing.geo_filter_time > Duration::ZERO {
+                entries.insert("search_execution > geo > filter".to_string(), timing.geo_filter_time);
+            }
+            if timing.geo_sort_time > Duration::ZERO {
+                entries.insert("search_execution > geo > sort".to_string(), timing.geo_sort_time);
+            }
+            if timing.geo_sort_compute_time > Duration::ZERO {
+                entries.insert("search_execution > geo > sort > compute".to_string(), timing.geo_sort_compute_time);
+            }
+            if timing.geo_bucket_sort_time > Duration::ZERO {
+                entries.insert("search_execution > geo > sort > bucket".to_string(), timing.geo_bucket_sort_time);
+            }
+            
+            // Cache and database
+            if timing.cache_lookup_time > Duration::ZERO {
+                entries.insert("search_execution > cache > lookup".to_string(), timing.cache_lookup_time);
+            }
+            if timing.database_read_time > Duration::ZERO {
+                entries.insert("search_execution > database > read".to_string(), timing.database_read_time);
+            }
+            if timing.filter_application_time > Duration::ZERO {
+                entries.insert("search_execution > database > filter".to_string(), timing.filter_application_time);
+            }
+        }
+        
+        // Result formatting hierarchy
+        if timing.result_formatting_time > Duration::ZERO {
+            entries.insert("result_formatting".to_string(), timing.result_formatting_time);
+            
+            if timing.result_sorting_time > Duration::ZERO {
+                entries.insert("result_formatting > sorting".to_string(), timing.result_sorting_time);
+            }
+            if timing.distinct_processing_time > Duration::ZERO {
+                entries.insert("result_formatting > distinct".to_string(), timing.distinct_processing_time);
+            }
+            if timing.pagination_time > Duration::ZERO {
+                entries.insert("result_formatting > pagination".to_string(), timing.pagination_time);
+            }
+        }
+        
+        // Facet operations hierarchy
+        if timing.facet_distribution_time > Duration::ZERO || timing.facet_stats_time > Duration::ZERO || timing.facet_search_time > Duration::ZERO {
+            let total_facet_time = timing.facet_distribution_time + timing.facet_stats_time + timing.facet_search_time;
+            entries.insert("facets".to_string(), total_facet_time);
+            
+            if timing.facet_distribution_time > Duration::ZERO {
+                entries.insert("facets > distribution".to_string(), timing.facet_distribution_time);
+            }
+            if timing.facet_stats_time > Duration::ZERO {
+                entries.insert("facets > stats".to_string(), timing.facet_stats_time);
+            }
+            if timing.facet_search_time > Duration::ZERO {
+                entries.insert("facets > search".to_string(), timing.facet_search_time);
+            }
+            
+            // Per-attribute facet timing
+            for (attr, duration) in &timing.facet_attribute_timing {
+                if *duration > Duration::ZERO {
+                    entries.insert(format!("facets > attribute > {}", attr), *duration);
+                }
+            }
+        }
+        
+        // Per-attribute filter timing
+        for (attr, duration) in &timing.filter_attribute_timing {
+            if *duration > Duration::ZERO {
+                entries.insert(format!("search_execution > database > filter > {}", attr), *duration);
+            }
+        }
+        
+        // Additional timing entries
+        for (key, duration) in &timing.additional_timing {
+            if *duration > Duration::ZERO {
+                entries.insert(format!("additional > {}", key), *duration);
+            }
+        }
+        
+        Self { timing_entries: entries }
+    }
 }
 
 #[derive(Serialize, Debug, Clone, PartialEq, ToSchema)]
@@ -1273,6 +1440,8 @@ pub fn perform_search(
         matching_strategy: _,
         attributes_to_search_on: _,
         ranking_score_threshold: _,
+        filter: _,
+        distinct: _,
     } = query;
 
     // Collect timing information for result formatting
@@ -1293,10 +1462,10 @@ pub fn perform_search(
                 sort,
                 show_ranking_score,
                 show_ranking_score_details,
-                locales,
+                locales: locales.map(|l| l.into_iter().map(Into::into).collect()),
             },
             matching_words,
-            documents_ids.iter().zip(document_scores.iter()),
+            documents_ids.iter().copied().zip(document_scores.iter()),
         )?)
     })?;
 
@@ -1381,7 +1550,8 @@ pub fn perform_search(
         facet_distribution: facet_timing.as_ref().map(|f| f.distribution.clone()),
         facet_stats: facet_timing.map(|f| f.stats),
         semantic_hit_count,
-        detailed_timing: Some(detailed_timing),
+        detailed_timing: Some(detailed_timing.clone()),
+        hierarchical_timing: Some(SearchTimingHierarchy::from_flat_timing(&detailed_timing)),
         degraded,
         used_negative_operator,
     })
@@ -2290,8 +2460,8 @@ where
     F: FnOnce() -> Result<R, ResponseError>,
 {
     // Create a temporary tracing layer to collect events
-    let trace = tracing_trace::Trace::new();
-    let registry = tracing_subscriber::Registry::default().with(trace);
+    let (trace, layer) = tracing_trace::Trace::new(false);
+    let registry = tracing_subscriber::Registry::default().with(layer);
     let _guard = tracing::subscriber::set_default(registry);
 
     // Execute the operation
@@ -2299,9 +2469,9 @@ where
 
     // Collect the trace
     let mut receiver = trace.into_receiver();
-    let mut entries = Vec::new();
-    while let Some(entry) = receiver.recv() {
-        entries.push(entry);
+    let mut buffer = Vec::new();
+    while let Some(entry) = receiver.blocking_recv() {
+        serde_json::to_writer(&mut buffer, &entry).unwrap();
     }
 
     // Process the entries to extract timing information
@@ -2345,9 +2515,9 @@ where
     };
 
     // Process the trace entries to extract timing information
-    if let Ok(stats) = tracing_trace::processor::span_stats::to_call_stats(&entries) {
+    if let Ok(stats) = tracing_trace::processor::span_stats::to_call_stats(tracing_trace::TraceReader::new(buffer.as_slice())) {
         for (span_name, stat) in stats {
-            let time_ms = stat.total_duration.as_millis() as u64;
+            let time_ms = stat.time / 1_000_000; // Convert nanoseconds to milliseconds
             
             match span_name.as_str() {
                 // Tokenization
@@ -2369,8 +2539,25 @@ where
                     timing.embedding_time += Duration::from_millis(time_ms);
                 }
                 
+                // Keyword search (placeholder for now)
+                "search::keyword" => {
+                    timing.keyword_search_time += Duration::from_millis(time_ms);
+                }
+                
                 // Query processing
                 "search::query" => {
+                    timing.query_processing_time += Duration::from_millis(time_ms);
+                }
+                "search::query::parse" => {
+                    timing.query_parsing_time += Duration::from_millis(time_ms);
+                    timing.query_processing_time += Duration::from_millis(time_ms);
+                }
+                "search::query::tree_build" => {
+                    timing.query_tree_build_time += Duration::from_millis(time_ms);
+                    timing.query_processing_time += Duration::from_millis(time_ms);
+                }
+                "search::query::simplify" => {
+                    timing.query_tree_simplify_time += Duration::from_millis(time_ms);
                     timing.query_processing_time += Duration::from_millis(time_ms);
                 }
                 "search::universe" => {
@@ -2437,6 +2624,11 @@ where
                 }
                 "search::results::limit" => {
                     timing.pagination_time += Duration::from_millis(time_ms);
+                }
+                
+                // Placeholder search execution
+                "search::main::placeholder_search_execution" => {
+                    timing.search_execution_time += Duration::from_millis(time_ms);
                 }
                 
                 // Cache and database

--- a/crates/meilisearch/src/search/mod.rs
+++ b/crates/meilisearch/src/search/mod.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use deserr::Deserr;
+use tracing_subscriber::layer::SubscriberExt;
 use either::Either;
 use index_scheduler::RoFeatures;
 use indexmap::IndexMap;
@@ -836,7 +837,6 @@ pub struct SearchHit {
 }
 
 #[derive(Serialize, Clone, PartialEq, ToSchema)]
-#[serde(rename_all = "camelCase")]
 #[schema(rename_all = "camelCase")]
 pub struct SearchResult {
     pub hits: Vec<SearchHit>,
@@ -852,6 +852,9 @@ pub struct SearchResult {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub semantic_hit_count: Option<u32>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detailed_timing: Option<SearchTiming>,
 
     // These fields are only used for analytics purposes
     #[serde(skip)]
@@ -872,6 +875,7 @@ impl fmt::Debug for SearchResult {
             semantic_hit_count,
             degraded,
             used_negative_operator,
+            detailed_timing,
         } = self;
 
         let mut debug = f.debug_struct("SearchResult");
@@ -894,6 +898,9 @@ impl fmt::Debug for SearchResult {
         }
         if let Some(semantic_hit_count) = semantic_hit_count {
             debug.field("semantic_hit_count", &semantic_hit_count);
+        }
+        if let Some(detailed_timing) = detailed_timing {
+            debug.field("detailed_timing", &detailed_timing);
         }
 
         debug.finish()
@@ -936,8 +943,32 @@ pub struct FacetStats {
     pub max: f64,
 }
 
-#[derive(Serialize, Debug, Clone, PartialEq)]
-#[serde(rename_all = "camelCase")]
+#[derive(Serialize, Debug, Clone, PartialEq, ToSchema)]
+#[schema(rename_all = "camelCase")]
+pub struct SearchTiming {
+    /// Total time for the entire search operation
+    pub total_time_ms: u64,
+    /// Time for keyword search operations
+    pub keyword_search_ms: Option<u64>,
+    /// Time for vector search operations
+    pub vector_search_ms: Option<u64>,
+    /// Time for hybrid search operations
+    pub hybrid_search_ms: Option<u64>,
+    /// Time for embedding operations
+    pub embedding_ms: Option<u64>,
+    /// Time for tokenization operations
+    pub tokenization_ms: Option<u64>,
+    /// Time for facet computation
+    pub facets_ms: Option<u64>,
+    /// Time for result formatting
+    pub formatting_ms: Option<u64>,
+    /// Additional timing information for specific operations
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub additional_timing: Option<BTreeMap<String, u64>>,
+}
+
+#[derive(Serialize, Debug, Clone, PartialEq, ToSchema)]
+#[schema(rename_all = "camelCase")]
 pub struct FacetSearchResult {
     pub facet_hits: Vec<FacetValueHit>,
     pub facet_query: Option<String>,
@@ -1123,6 +1154,11 @@ pub fn perform_search(
     let (search, is_finite_pagination, max_total_hits, offset) =
         prepare_search(index, &rtxn, &query, &search_kind, time_budget, features)?;
 
+    // Collect timing information for the core search operation
+    let ((search_result, semantic_hit_count), search_timing) = collect_search_timing(|| {
+        Ok(search_from_kind(index_uid.clone(), search_kind.clone(), search)?)
+    })?;
+
     let (
         milli::SearchResult {
             documents_ids,
@@ -1133,7 +1169,7 @@ pub fn perform_search(
             used_negative_operator,
         },
         semantic_hit_count,
-    ) = search_from_kind(index_uid, search_kind, search)?;
+    ) = (search_result, semantic_hit_count);
 
     let SearchQuery {
         q,
@@ -1183,13 +1219,16 @@ pub fn perform_search(
         locales: locales.map(|l| l.iter().copied().map(Into::into).collect()),
     };
 
-    let documents = make_hits(
-        index,
-        &rtxn,
-        format,
-        matching_words,
-        documents_ids.iter().copied().zip(document_scores.iter()),
-    )?;
+    // Collect timing information for result formatting
+    let (documents, formatting_timing) = collect_search_timing(|| {
+        Ok(make_hits(
+            index,
+            &rtxn,
+            format,
+            matching_words,
+            documents_ids.iter().copied().zip(document_scores.iter()),
+        )?)
+    })?;
 
     let number_of_hits = min(candidates.len() as usize, max_total_hits);
     let hits_info = if is_finite_pagination {
@@ -1209,13 +1248,46 @@ pub fn perform_search(
         HitsInfo::OffsetLimit { limit, offset, estimated_total_hits: number_of_hits }
     };
 
-    let (facet_distribution, facet_stats) = facets
+    // Collect timing information for facet computation
+    let (facet_result, facet_timing) = facets
         .map(move |facets| {
-            compute_facet_distribution_stats(&facets, index, &rtxn, candidates, Route::Search)
+            collect_search_timing(|| {
+                compute_facet_distribution_stats(&facets, index, &rtxn, candidates, Route::Search)
+            })
         })
         .transpose()?
+        .map(|(facets, timing)| (facets, Some(timing)))
+        .unzip();
+
+    let (facet_distribution, facet_stats) = facet_result
         .map(|ComputedFacets { distribution, stats }| (distribution, stats))
         .unzip();
+
+    // Combine all timing information
+    let detailed_timing = SearchTiming {
+        total_time_ms: before_search.elapsed().as_millis() as u64,
+        keyword_search_ms: search_timing.keyword_search_ms,
+        vector_search_ms: search_timing.vector_search_ms,
+        hybrid_search_ms: search_timing.hybrid_search_ms,
+        embedding_ms: search_timing.embedding_ms,
+        tokenization_ms: search_timing.tokenization_ms,
+        facets_ms: facet_timing.clone().flatten().and_then(|t| t.facets_ms),
+        formatting_ms: formatting_timing.formatting_ms,
+        additional_timing: {
+            let mut additional = search_timing.additional_timing.unwrap_or_default();
+            if let Some(formatting_additional) = formatting_timing.additional_timing {
+                additional.extend(formatting_additional);
+            }
+            if let Some(facet_additional) = facet_timing.flatten().and_then(|t| t.additional_timing) {
+                additional.extend(facet_additional);
+            }
+            if !additional.is_empty() {
+                Some(additional)
+            } else {
+                None
+            }
+        },
+    };
 
     let result = SearchResult {
         hits: documents,
@@ -1227,6 +1299,7 @@ pub fn perform_search(
         degraded,
         used_negative_operator,
         semantic_hit_count,
+        detailed_timing: Some(detailed_timing),
     };
     Ok(result)
 }
@@ -2121,4 +2194,77 @@ fn parse_filter_array(arr: &[Value]) -> Result<Option<Filter>, MeilisearchHttpEr
     }
 
     Filter::from_array(ands).map_err(|e| MeilisearchHttpError::from_milli(e, None))
+}
+
+/// Collect timing information from tracing spans
+/// This function creates a temporary tracing layer to collect timing information
+/// from the various search operations
+fn collect_search_timing<F, R>(operation: F) -> Result<(R, SearchTiming), ResponseError>
+where
+    F: FnOnce() -> Result<R, ResponseError>,
+{
+    use tracing_trace::Trace;
+
+    // Create a temporary tracing layer to collect timing information
+    let (trace, layer) = Trace::new(false);
+    let guard = tracing::subscriber::set_default(tracing_subscriber::Registry::default().with(layer));
+
+    // Execute the search operation
+    let result = operation()?;
+
+    // Drop the guard to restore the original subscriber
+    drop(guard);
+
+    // Collect timing information from the trace
+    let mut receiver = trace.into_receiver();
+    let mut entries = Vec::new();
+    
+    // Collect all entries from the trace
+    while let Ok(entry) = receiver.try_recv() {
+        entries.push(entry);
+    }
+
+    // Process the entries to extract timing information
+    let mut timing = SearchTiming {
+        total_time_ms: 0,
+        keyword_search_ms: None,
+        vector_search_ms: None,
+        hybrid_search_ms: None,
+        embedding_ms: None,
+        tokenization_ms: None,
+        facets_ms: None,
+        formatting_ms: None,
+        additional_timing: Some(BTreeMap::new()),
+    };
+
+    // Process the trace entries to extract timing information
+    // This is a simplified version - in practice, you'd want to use the tracing_trace processor
+    if let Ok(stats) = tracing_trace::processor::span_stats::to_call_stats(
+        tracing_trace::TraceReader::new(std::io::Cursor::new(
+            serde_json::to_string(&entries).unwrap_or_default()
+        ))
+    ) {
+        for (span_name, call_stats) in stats {
+            let time_ms = (call_stats.time as f64 / 1_000_000.0) as u64; // Convert nanoseconds to milliseconds
+            
+            match span_name.as_str() {
+                "search::tokens::tokenizer_builder" | "search::tokens::tokenize" => {
+                    timing.tokenization_ms = Some(timing.tokenization_ms.unwrap_or(0) + time_ms);
+                }
+                "search::vector::embed_one" => {
+                    timing.embedding_ms = Some(timing.embedding_ms.unwrap_or(0) + time_ms);
+                }
+                "search::hybrid::embed_one" => {
+                    timing.embedding_ms = Some(timing.embedding_ms.unwrap_or(0) + time_ms);
+                }
+                _ => {
+                    if let Some(ref mut additional) = timing.additional_timing {
+                        additional.insert(span_name, time_ms);
+                    }
+                }
+            }
+        }
+    }
+
+    Ok((result, timing))
 }

--- a/crates/meilisearch/src/search/mod.rs
+++ b/crates/meilisearch/src/search/mod.rs
@@ -947,7 +947,7 @@ pub struct FacetStats {
     pub max: f64,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema, Default)]
 pub struct SearchTiming {
     // Core timings
     pub total_search_time: Duration,
@@ -1046,143 +1046,143 @@ pub struct SearchTiming {
 /// Similar to indexing timing with parent-child relationships
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
 pub struct SearchTimingHierarchy {
-    /// The hierarchical timing entries with ">" separators
-    pub timing_entries: BTreeMap<String, Duration>,
+    /// The hierarchical timing entries with ">" separators, formatted as strings like Batch progress_trace
+    pub timing_entries: serde_json::Map<String, serde_json::Value>,
 }
 
 impl SearchTimingHierarchy {
     /// Convert flat SearchTiming to hierarchical format
     pub fn from_flat_timing(timing: &SearchTiming) -> Self {
-        let mut entries = BTreeMap::new();
+        let mut entries = serde_json::Map::new();
         
         // Core search structure
-        entries.insert("total_search".to_string(), timing.total_search_time);
+        entries.insert("total_search".to_string(), serde_json::Value::String(format!("{:.2?}", timing.total_search_time)));
         
         // Query processing hierarchy
         if timing.query_processing_time > Duration::ZERO {
-            entries.insert("query_processing".to_string(), timing.query_processing_time);
+            entries.insert("query_processing".to_string(), serde_json::Value::String(format!("{:.2?}", timing.query_processing_time)));
             
             if timing.query_parsing_time > Duration::ZERO {
-                entries.insert("query_processing > parsing".to_string(), timing.query_parsing_time);
+                entries.insert("query_processing > parsing".to_string(), serde_json::Value::String(format!("{:.2?}", timing.query_parsing_time)));
             }
             if timing.query_tree_build_time > Duration::ZERO {
-                entries.insert("query_processing > tree_build".to_string(), timing.query_tree_build_time);
+                entries.insert("query_processing > tree_build".to_string(), serde_json::Value::String(format!("{:.2?}", timing.query_tree_build_time)));
             }
             if timing.query_tree_simplify_time > Duration::ZERO {
-                entries.insert("query_processing > tree_simplify".to_string(), timing.query_tree_simplify_time);
+                entries.insert("query_processing > tree_simplify".to_string(), serde_json::Value::String(format!("{:.2?}", timing.query_tree_simplify_time)));
             }
             if timing.ranking_graph_build_time > Duration::ZERO {
-                entries.insert("query_processing > ranking_graph_build".to_string(), timing.ranking_graph_build_time);
+                entries.insert("query_processing > ranking_graph_build".to_string(), serde_json::Value::String(format!("{:.2?}", timing.ranking_graph_build_time)));
             }
         }
         
         // Tokenization hierarchy
         if timing.tokenization_time > Duration::ZERO {
-            entries.insert("tokenization".to_string(), timing.tokenization_time);
+            entries.insert("tokenization".to_string(), serde_json::Value::String(format!("{:.2?}", timing.tokenization_time)));
             
             if timing.tokenizer_build_time > Duration::ZERO {
-                entries.insert("tokenization > tokenizer_build".to_string(), timing.tokenizer_build_time);
+                entries.insert("tokenization > tokenizer_build".to_string(), serde_json::Value::String(format!("{:.2?}", timing.tokenizer_build_time)));
             }
         }
         
         // Search execution hierarchy
         if timing.search_execution_time > Duration::ZERO {
-            entries.insert("search_execution".to_string(), timing.search_execution_time);
+            entries.insert("search_execution".to_string(), serde_json::Value::String(format!("{:.2?}", timing.search_execution_time)));
             
             // Search types
             if timing.keyword_search_time > Duration::ZERO {
-                entries.insert("search_execution > keyword_search".to_string(), timing.keyword_search_time);
+                entries.insert("search_execution > keyword_search".to_string(), serde_json::Value::String(format!("{:.2?}", timing.keyword_search_time)));
             }
             if timing.vector_search_time > Duration::ZERO {
-                entries.insert("search_execution > vector_search".to_string(), timing.vector_search_time);
+                entries.insert("search_execution > vector_search".to_string(), serde_json::Value::String(format!("{:.2?}", timing.vector_search_time)));
             }
             if timing.hybrid_search_time > Duration::ZERO {
-                entries.insert("search_execution > hybrid_search".to_string(), timing.hybrid_search_time);
+                entries.insert("search_execution > hybrid_search".to_string(), serde_json::Value::String(format!("{:.2?}", timing.hybrid_search_time)));
             }
             if timing.embedding_time > Duration::ZERO {
-                entries.insert("search_execution > embedding".to_string(), timing.embedding_time);
+                entries.insert("search_execution > embedding".to_string(), serde_json::Value::String(format!("{:.2?}", timing.embedding_time)));
             }
             
             // Ranking rules
             if timing.words_ranking_time > Duration::ZERO {
-                entries.insert("search_execution > ranking > words".to_string(), timing.words_ranking_time);
+                entries.insert("search_execution > ranking > words".to_string(), serde_json::Value::String(format!("{:.2?}", timing.words_ranking_time)));
             }
             if timing.typo_ranking_time > Duration::ZERO {
-                entries.insert("search_execution > ranking > typo".to_string(), timing.typo_ranking_time);
+                entries.insert("search_execution > ranking > typo".to_string(), serde_json::Value::String(format!("{:.2?}", timing.typo_ranking_time)));
             }
             if timing.proximity_ranking_time > Duration::ZERO {
-                entries.insert("search_execution > ranking > proximity".to_string(), timing.proximity_ranking_time);
+                entries.insert("search_execution > ranking > proximity".to_string(), serde_json::Value::String(format!("{:.2?}", timing.proximity_ranking_time)));
             }
             if timing.attribute_ranking_time > Duration::ZERO {
-                entries.insert("search_execution > ranking > attribute".to_string(), timing.attribute_ranking_time);
+                entries.insert("search_execution > ranking > attribute".to_string(), serde_json::Value::String(format!("{:.2?}", timing.attribute_ranking_time)));
             }
             if timing.exactness_ranking_time > Duration::ZERO {
-                entries.insert("search_execution > ranking > exactness".to_string(), timing.exactness_ranking_time);
+                entries.insert("search_execution > ranking > exactness".to_string(), serde_json::Value::String(format!("{:.2?}", timing.exactness_ranking_time)));
             }
             if timing.sort_ranking_time > Duration::ZERO {
-                entries.insert("search_execution > ranking > sort".to_string(), timing.sort_ranking_time);
+                entries.insert("search_execution > ranking > sort".to_string(), serde_json::Value::String(format!("{:.2?}", timing.sort_ranking_time)));
             }
             
             // Geographic operations
             if timing.geo_filter_time > Duration::ZERO {
-                entries.insert("search_execution > geo > filter".to_string(), timing.geo_filter_time);
+                entries.insert("search_execution > geo > filter".to_string(), serde_json::Value::String(format!("{:.2?}", timing.geo_filter_time)));
             }
             if timing.geo_sort_time > Duration::ZERO {
-                entries.insert("search_execution > geo > sort".to_string(), timing.geo_sort_time);
+                entries.insert("search_execution > geo > sort".to_string(), serde_json::Value::String(format!("{:.2?}", timing.geo_sort_time)));
             }
             if timing.geo_sort_compute_time > Duration::ZERO {
-                entries.insert("search_execution > geo > sort > compute".to_string(), timing.geo_sort_compute_time);
+                entries.insert("search_execution > geo > sort > compute".to_string(), serde_json::Value::String(format!("{:.2?}", timing.geo_sort_compute_time)));
             }
             if timing.geo_bucket_sort_time > Duration::ZERO {
-                entries.insert("search_execution > geo > sort > bucket".to_string(), timing.geo_bucket_sort_time);
+                entries.insert("search_execution > geo > sort > bucket".to_string(), serde_json::Value::String(format!("{:.2?}", timing.geo_bucket_sort_time)));
             }
             
             // Cache and database
             if timing.cache_lookup_time > Duration::ZERO {
-                entries.insert("search_execution > cache > lookup".to_string(), timing.cache_lookup_time);
+                entries.insert("search_execution > cache > lookup".to_string(), serde_json::Value::String(format!("{:.2?}", timing.cache_lookup_time)));
             }
             if timing.database_read_time > Duration::ZERO {
-                entries.insert("search_execution > database > read".to_string(), timing.database_read_time);
+                entries.insert("search_execution > database > read".to_string(), serde_json::Value::String(format!("{:.2?}", timing.database_read_time)));
             }
             if timing.filter_application_time > Duration::ZERO {
-                entries.insert("search_execution > database > filter".to_string(), timing.filter_application_time);
+                entries.insert("search_execution > database > filter".to_string(), serde_json::Value::String(format!("{:.2?}", timing.filter_application_time)));
             }
         }
         
         // Result formatting hierarchy
         if timing.result_formatting_time > Duration::ZERO {
-            entries.insert("result_formatting".to_string(), timing.result_formatting_time);
+            entries.insert("result_formatting".to_string(), serde_json::Value::String(format!("{:.2?}", timing.result_formatting_time)));
             
             if timing.result_sorting_time > Duration::ZERO {
-                entries.insert("result_formatting > sorting".to_string(), timing.result_sorting_time);
+                entries.insert("result_formatting > sorting".to_string(), serde_json::Value::String(format!("{:.2?}", timing.result_sorting_time)));
             }
             if timing.distinct_processing_time > Duration::ZERO {
-                entries.insert("result_formatting > distinct".to_string(), timing.distinct_processing_time);
+                entries.insert("result_formatting > distinct".to_string(), serde_json::Value::String(format!("{:.2?}", timing.distinct_processing_time)));
             }
             if timing.pagination_time > Duration::ZERO {
-                entries.insert("result_formatting > pagination".to_string(), timing.pagination_time);
+                entries.insert("result_formatting > pagination".to_string(), serde_json::Value::String(format!("{:.2?}", timing.pagination_time)));
             }
         }
         
         // Facet operations hierarchy
         if timing.facet_distribution_time > Duration::ZERO || timing.facet_stats_time > Duration::ZERO || timing.facet_search_time > Duration::ZERO {
             let total_facet_time = timing.facet_distribution_time + timing.facet_stats_time + timing.facet_search_time;
-            entries.insert("facets".to_string(), total_facet_time);
+            entries.insert("facets".to_string(), serde_json::Value::String(format!("{:.2?}", total_facet_time)));
             
             if timing.facet_distribution_time > Duration::ZERO {
-                entries.insert("facets > distribution".to_string(), timing.facet_distribution_time);
+                entries.insert("facets > distribution".to_string(), serde_json::Value::String(format!("{:.2?}", timing.facet_distribution_time)));
             }
             if timing.facet_stats_time > Duration::ZERO {
-                entries.insert("facets > stats".to_string(), timing.facet_stats_time);
+                entries.insert("facets > stats".to_string(), serde_json::Value::String(format!("{:.2?}", timing.facet_stats_time)));
             }
             if timing.facet_search_time > Duration::ZERO {
-                entries.insert("facets > search".to_string(), timing.facet_search_time);
+                entries.insert("facets > search".to_string(), serde_json::Value::String(format!("{:.2?}", timing.facet_search_time)));
             }
             
             // Per-attribute facet timing
             for (attr, duration) in &timing.facet_attribute_timing {
                 if *duration > Duration::ZERO {
-                    entries.insert(format!("facets > attribute > {}", attr), *duration);
+                    entries.insert(format!("facets > attribute > {}", attr), serde_json::Value::String(format!("{:.2?}", duration)));
                 }
             }
         }
@@ -1190,14 +1190,14 @@ impl SearchTimingHierarchy {
         // Per-attribute filter timing
         for (attr, duration) in &timing.filter_attribute_timing {
             if *duration > Duration::ZERO {
-                entries.insert(format!("search_execution > database > filter > {}", attr), *duration);
+                entries.insert(format!("search_execution > database > filter > {}", attr), serde_json::Value::String(format!("{:.2?}", duration)));
             }
         }
         
         // Additional timing entries
         for (key, duration) in &timing.additional_timing {
             if *duration > Duration::ZERO {
-                entries.insert(format!("additional > {}", key), *duration);
+                entries.insert(format!("additional > {}", key), serde_json::Value::String(format!("{:.2?}", duration)));
             }
         }
         

--- a/crates/meilisearch/src/search/mod.rs
+++ b/crates/meilisearch/src/search/mod.rs
@@ -854,10 +854,7 @@ pub struct SearchResult {
     pub semantic_hit_count: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub detailed_timing: Option<SearchTiming>,
-    
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub hierarchical_timing: Option<SearchTimingHierarchy>,
+    pub detailed_timing: Option<SearchTimingHierarchy>,
 
     // These fields are only used for analytics purposes
     #[serde(skip)]
@@ -879,7 +876,6 @@ impl fmt::Debug for SearchResult {
             degraded,
             used_negative_operator,
             detailed_timing,
-            hierarchical_timing: _,
         } = self;
 
         let mut debug = f.debug_struct("SearchResult");
@@ -1055,134 +1051,182 @@ impl SearchTimingHierarchy {
     pub fn from_flat_timing(timing: &SearchTiming) -> Self {
         let mut entries = serde_json::Map::new();
         
-        // Core search structure
-        entries.insert("total_search".to_string(), serde_json::Value::String(format!("{:.2?}", timing.total_search_time)));
+        // Core search structure - renamed to processing_time_ms
+        entries.insert("processing_time_ms".to_string(), serde_json::Value::String(format!("{:.2?}", timing.total_search_time)));
         
         // Query processing hierarchy
         if timing.query_processing_time > Duration::ZERO {
-            entries.insert("query_processing".to_string(), serde_json::Value::String(format!("{:.2?}", timing.query_processing_time)));
+            // Check if this is the only non-zero child of total_search
+            let has_other_children = timing.search_execution_time > Duration::ZERO 
+                || timing.result_formatting_time > Duration::ZERO 
+                || timing.facet_distribution_time > Duration::ZERO 
+                || timing.facet_stats_time > Duration::ZERO 
+                || timing.facet_search_time > Duration::ZERO;
             
-            if timing.query_parsing_time > Duration::ZERO {
-                entries.insert("query_processing > parsing".to_string(), serde_json::Value::String(format!("{:.2?}", timing.query_parsing_time)));
-            }
-            if timing.query_tree_build_time > Duration::ZERO {
-                entries.insert("query_processing > tree_build".to_string(), serde_json::Value::String(format!("{:.2?}", timing.query_tree_build_time)));
-            }
-            if timing.query_tree_simplify_time > Duration::ZERO {
-                entries.insert("query_processing > tree_simplify".to_string(), serde_json::Value::String(format!("{:.2?}", timing.query_tree_simplify_time)));
-            }
-            if timing.ranking_graph_build_time > Duration::ZERO {
-                entries.insert("query_processing > ranking_graph_build".to_string(), serde_json::Value::String(format!("{:.2?}", timing.ranking_graph_build_time)));
+            if has_other_children {
+                entries.insert("query_processing".to_string(), serde_json::Value::String(format!("{:.2?}", timing.query_processing_time)));
+                
+                if timing.query_parsing_time > Duration::ZERO {
+                    entries.insert("query_processing > parsing".to_string(), serde_json::Value::String(format!("{:.2?}", timing.query_parsing_time)));
+                }
+                if timing.query_tree_build_time > Duration::ZERO {
+                    entries.insert("query_processing > tree_build".to_string(), serde_json::Value::String(format!("{:.2?}", timing.query_tree_build_time)));
+                }
+                if timing.query_tree_simplify_time > Duration::ZERO {
+                    entries.insert("query_processing > tree_simplify".to_string(), serde_json::Value::String(format!("{:.2?}", timing.query_tree_simplify_time)));
+                }
+                if timing.ranking_graph_build_time > Duration::ZERO {
+                    entries.insert("query_processing > ranking_graph_build".to_string(), serde_json::Value::String(format!("{:.2?}", timing.ranking_graph_build_time)));
+                }
             }
         }
         
         // Tokenization hierarchy
         if timing.tokenization_time > Duration::ZERO {
-            entries.insert("tokenization".to_string(), serde_json::Value::String(format!("{:.2?}", timing.tokenization_time)));
+            // Check if this is the only non-zero child of total_search
+            let has_other_children = timing.query_processing_time > Duration::ZERO 
+                || timing.search_execution_time > Duration::ZERO 
+                || timing.result_formatting_time > Duration::ZERO 
+                || timing.facet_distribution_time > Duration::ZERO 
+                || timing.facet_stats_time > Duration::ZERO 
+                || timing.facet_search_time > Duration::ZERO;
             
-            if timing.tokenizer_build_time > Duration::ZERO {
-                entries.insert("tokenization > tokenizer_build".to_string(), serde_json::Value::String(format!("{:.2?}", timing.tokenizer_build_time)));
+            if has_other_children {
+                entries.insert("tokenization".to_string(), serde_json::Value::String(format!("{:.2?}", timing.tokenization_time)));
+                
+                if timing.tokenizer_build_time > Duration::ZERO {
+                    entries.insert("tokenization > tokenizer_build".to_string(), serde_json::Value::String(format!("{:.2?}", timing.tokenizer_build_time)));
+                }
             }
         }
         
         // Search execution hierarchy
         if timing.search_execution_time > Duration::ZERO {
-            entries.insert("search_execution".to_string(), serde_json::Value::String(format!("{:.2?}", timing.search_execution_time)));
+            // Check if this is the only non-zero child of total_search
+            let has_other_children = timing.query_processing_time > Duration::ZERO 
+                || timing.tokenization_time > Duration::ZERO 
+                || timing.result_formatting_time > Duration::ZERO 
+                || timing.facet_distribution_time > Duration::ZERO 
+                || timing.facet_stats_time > Duration::ZERO 
+                || timing.facet_search_time > Duration::ZERO;
             
-            // Search types
-            if timing.keyword_search_time > Duration::ZERO {
-                entries.insert("search_execution > keyword_search".to_string(), serde_json::Value::String(format!("{:.2?}", timing.keyword_search_time)));
-            }
-            if timing.vector_search_time > Duration::ZERO {
-                entries.insert("search_execution > vector_search".to_string(), serde_json::Value::String(format!("{:.2?}", timing.vector_search_time)));
-            }
-            if timing.hybrid_search_time > Duration::ZERO {
-                entries.insert("search_execution > hybrid_search".to_string(), serde_json::Value::String(format!("{:.2?}", timing.hybrid_search_time)));
-            }
-            if timing.embedding_time > Duration::ZERO {
-                entries.insert("search_execution > embedding".to_string(), serde_json::Value::String(format!("{:.2?}", timing.embedding_time)));
-            }
-            
-            // Ranking rules
-            if timing.words_ranking_time > Duration::ZERO {
-                entries.insert("search_execution > ranking > words".to_string(), serde_json::Value::String(format!("{:.2?}", timing.words_ranking_time)));
-            }
-            if timing.typo_ranking_time > Duration::ZERO {
-                entries.insert("search_execution > ranking > typo".to_string(), serde_json::Value::String(format!("{:.2?}", timing.typo_ranking_time)));
-            }
-            if timing.proximity_ranking_time > Duration::ZERO {
-                entries.insert("search_execution > ranking > proximity".to_string(), serde_json::Value::String(format!("{:.2?}", timing.proximity_ranking_time)));
-            }
-            if timing.attribute_ranking_time > Duration::ZERO {
-                entries.insert("search_execution > ranking > attribute".to_string(), serde_json::Value::String(format!("{:.2?}", timing.attribute_ranking_time)));
-            }
-            if timing.exactness_ranking_time > Duration::ZERO {
-                entries.insert("search_execution > ranking > exactness".to_string(), serde_json::Value::String(format!("{:.2?}", timing.exactness_ranking_time)));
-            }
-            if timing.sort_ranking_time > Duration::ZERO {
-                entries.insert("search_execution > ranking > sort".to_string(), serde_json::Value::String(format!("{:.2?}", timing.sort_ranking_time)));
-            }
-            
-            // Geographic operations
-            if timing.geo_filter_time > Duration::ZERO {
-                entries.insert("search_execution > geo > filter".to_string(), serde_json::Value::String(format!("{:.2?}", timing.geo_filter_time)));
-            }
-            if timing.geo_sort_time > Duration::ZERO {
-                entries.insert("search_execution > geo > sort".to_string(), serde_json::Value::String(format!("{:.2?}", timing.geo_sort_time)));
-            }
-            if timing.geo_sort_compute_time > Duration::ZERO {
-                entries.insert("search_execution > geo > sort > compute".to_string(), serde_json::Value::String(format!("{:.2?}", timing.geo_sort_compute_time)));
-            }
-            if timing.geo_bucket_sort_time > Duration::ZERO {
-                entries.insert("search_execution > geo > sort > bucket".to_string(), serde_json::Value::String(format!("{:.2?}", timing.geo_bucket_sort_time)));
-            }
-            
-            // Cache and database
-            if timing.cache_lookup_time > Duration::ZERO {
-                entries.insert("search_execution > cache > lookup".to_string(), serde_json::Value::String(format!("{:.2?}", timing.cache_lookup_time)));
-            }
-            if timing.database_read_time > Duration::ZERO {
-                entries.insert("search_execution > database > read".to_string(), serde_json::Value::String(format!("{:.2?}", timing.database_read_time)));
-            }
-            if timing.filter_application_time > Duration::ZERO {
-                entries.insert("search_execution > database > filter".to_string(), serde_json::Value::String(format!("{:.2?}", timing.filter_application_time)));
+            if has_other_children {
+                entries.insert("search_execution".to_string(), serde_json::Value::String(format!("{:.2?}", timing.search_execution_time)));
+                
+                // Search types
+                if timing.keyword_search_time > Duration::ZERO {
+                    entries.insert("search_execution > keyword_search".to_string(), serde_json::Value::String(format!("{:.2?}", timing.keyword_search_time)));
+                }
+                if timing.vector_search_time > Duration::ZERO {
+                    entries.insert("search_execution > vector_search".to_string(), serde_json::Value::String(format!("{:.2?}", timing.vector_search_time)));
+                }
+                if timing.hybrid_search_time > Duration::ZERO {
+                    entries.insert("search_execution > hybrid_search".to_string(), serde_json::Value::String(format!("{:.2?}", timing.hybrid_search_time)));
+                }
+                if timing.embedding_time > Duration::ZERO {
+                    entries.insert("search_execution > embedding".to_string(), serde_json::Value::String(format!("{:.2?}", timing.embedding_time)));
+                }
+                
+                // Ranking rules
+                if timing.words_ranking_time > Duration::ZERO {
+                    entries.insert("search_execution > ranking > words".to_string(), serde_json::Value::String(format!("{:.2?}", timing.words_ranking_time)));
+                }
+                if timing.typo_ranking_time > Duration::ZERO {
+                    entries.insert("search_execution > ranking > typo".to_string(), serde_json::Value::String(format!("{:.2?}", timing.typo_ranking_time)));
+                }
+                if timing.proximity_ranking_time > Duration::ZERO {
+                    entries.insert("search_execution > ranking > proximity".to_string(), serde_json::Value::String(format!("{:.2?}", timing.proximity_ranking_time)));
+                }
+                if timing.attribute_ranking_time > Duration::ZERO {
+                    entries.insert("search_execution > ranking > attribute".to_string(), serde_json::Value::String(format!("{:.2?}", timing.attribute_ranking_time)));
+                }
+                if timing.exactness_ranking_time > Duration::ZERO {
+                    entries.insert("search_execution > ranking > exactness".to_string(), serde_json::Value::String(format!("{:.2?}", timing.exactness_ranking_time)));
+                }
+                if timing.sort_ranking_time > Duration::ZERO {
+                    entries.insert("search_execution > ranking > sort".to_string(), serde_json::Value::String(format!("{:.2?}", timing.sort_ranking_time)));
+                }
+                
+                // Geographic operations
+                if timing.geo_filter_time > Duration::ZERO {
+                    entries.insert("search_execution > geo > filter".to_string(), serde_json::Value::String(format!("{:.2?}", timing.geo_filter_time)));
+                }
+                if timing.geo_sort_time > Duration::ZERO {
+                    entries.insert("search_execution > geo > sort".to_string(), serde_json::Value::String(format!("{:.2?}", timing.geo_sort_time)));
+                }
+                if timing.geo_sort_compute_time > Duration::ZERO {
+                    entries.insert("search_execution > geo > sort > compute".to_string(), serde_json::Value::String(format!("{:.2?}", timing.geo_sort_compute_time)));
+                }
+                if timing.geo_bucket_sort_time > Duration::ZERO {
+                    entries.insert("search_execution > geo > sort > bucket".to_string(), serde_json::Value::String(format!("{:.2?}", timing.geo_bucket_sort_time)));
+                }
+                
+                // Cache and database
+                if timing.cache_lookup_time > Duration::ZERO {
+                    entries.insert("search_execution > cache > lookup".to_string(), serde_json::Value::String(format!("{:.2?}", timing.cache_lookup_time)));
+                }
+                if timing.database_read_time > Duration::ZERO {
+                    entries.insert("search_execution > database > read".to_string(), serde_json::Value::String(format!("{:.2?}", timing.database_read_time)));
+                }
+                if timing.filter_application_time > Duration::ZERO {
+                    entries.insert("search_execution > database > filter".to_string(), serde_json::Value::String(format!("{:.2?}", timing.filter_application_time)));
+                }
             }
         }
         
         // Result formatting hierarchy
         if timing.result_formatting_time > Duration::ZERO {
-            entries.insert("result_formatting".to_string(), serde_json::Value::String(format!("{:.2?}", timing.result_formatting_time)));
+            // Check if this is the only non-zero child of total_search
+            let has_other_children = timing.query_processing_time > Duration::ZERO 
+                || timing.tokenization_time > Duration::ZERO 
+                || timing.search_execution_time > Duration::ZERO 
+                || timing.facet_distribution_time > Duration::ZERO 
+                || timing.facet_stats_time > Duration::ZERO 
+                || timing.facet_search_time > Duration::ZERO;
             
-            if timing.result_sorting_time > Duration::ZERO {
-                entries.insert("result_formatting > sorting".to_string(), serde_json::Value::String(format!("{:.2?}", timing.result_sorting_time)));
-            }
-            if timing.distinct_processing_time > Duration::ZERO {
-                entries.insert("result_formatting > distinct".to_string(), serde_json::Value::String(format!("{:.2?}", timing.distinct_processing_time)));
-            }
-            if timing.pagination_time > Duration::ZERO {
-                entries.insert("result_formatting > pagination".to_string(), serde_json::Value::String(format!("{:.2?}", timing.pagination_time)));
+            if has_other_children {
+                entries.insert("result_formatting".to_string(), serde_json::Value::String(format!("{:.2?}", timing.result_formatting_time)));
+                
+                if timing.result_sorting_time > Duration::ZERO {
+                    entries.insert("result_formatting > sorting".to_string(), serde_json::Value::String(format!("{:.2?}", timing.result_sorting_time)));
+                }
+                if timing.distinct_processing_time > Duration::ZERO {
+                    entries.insert("result_formatting > distinct".to_string(), serde_json::Value::String(format!("{:.2?}", timing.distinct_processing_time)));
+                }
+                if timing.pagination_time > Duration::ZERO {
+                    entries.insert("result_formatting > pagination".to_string(), serde_json::Value::String(format!("{:.2?}", timing.pagination_time)));
+                }
             }
         }
         
         // Facet operations hierarchy
         if timing.facet_distribution_time > Duration::ZERO || timing.facet_stats_time > Duration::ZERO || timing.facet_search_time > Duration::ZERO {
             let total_facet_time = timing.facet_distribution_time + timing.facet_stats_time + timing.facet_search_time;
-            entries.insert("facets".to_string(), serde_json::Value::String(format!("{:.2?}", total_facet_time)));
             
-            if timing.facet_distribution_time > Duration::ZERO {
-                entries.insert("facets > distribution".to_string(), serde_json::Value::String(format!("{:.2?}", timing.facet_distribution_time)));
-            }
-            if timing.facet_stats_time > Duration::ZERO {
-                entries.insert("facets > stats".to_string(), serde_json::Value::String(format!("{:.2?}", timing.facet_stats_time)));
-            }
-            if timing.facet_search_time > Duration::ZERO {
-                entries.insert("facets > search".to_string(), serde_json::Value::String(format!("{:.2?}", timing.facet_search_time)));
-            }
+            // Check if this is the only non-zero child of total_search
+            let has_other_children = timing.query_processing_time > Duration::ZERO 
+                || timing.tokenization_time > Duration::ZERO 
+                || timing.search_execution_time > Duration::ZERO 
+                || timing.result_formatting_time > Duration::ZERO;
             
-            // Per-attribute facet timing
-            for (attr, duration) in &timing.facet_attribute_timing {
-                if *duration > Duration::ZERO {
-                    entries.insert(format!("facets > attribute > {}", attr), serde_json::Value::String(format!("{:.2?}", duration)));
+            if has_other_children {
+                entries.insert("facets".to_string(), serde_json::Value::String(format!("{:.2?}", total_facet_time)));
+                
+                if timing.facet_distribution_time > Duration::ZERO {
+                    entries.insert("facets > distribution".to_string(), serde_json::Value::String(format!("{:.2?}", timing.facet_distribution_time)));
+                }
+                if timing.facet_stats_time > Duration::ZERO {
+                    entries.insert("facets > stats".to_string(), serde_json::Value::String(format!("{:.2?}", timing.facet_stats_time)));
+                }
+                if timing.facet_search_time > Duration::ZERO {
+                    entries.insert("facets > search".to_string(), serde_json::Value::String(format!("{:.2?}", timing.facet_search_time)));
+                }
+                
+                // Per-attribute facet timing
+                for (attr, duration) in &timing.facet_attribute_timing {
+                    if *duration > Duration::ZERO {
+                        entries.insert(format!("facets > attribute > {}", attr), serde_json::Value::String(format!("{:.2?}", duration)));
+                    }
                 }
             }
         }
@@ -1550,8 +1594,7 @@ pub fn perform_search(
         facet_distribution: facet_timing.as_ref().map(|f| f.distribution.clone()),
         facet_stats: facet_timing.map(|f| f.stats),
         semantic_hit_count,
-        detailed_timing: Some(detailed_timing.clone()),
-        hierarchical_timing: Some(SearchTimingHierarchy::from_flat_timing(&detailed_timing)),
+        detailed_timing: Some(SearchTimingHierarchy::from_flat_timing(&detailed_timing)),
         degraded,
         used_negative_operator,
     })

--- a/crates/meilisearch/src/search/mod_test.rs
+++ b/crates/meilisearch/src/search/mod_test.rs
@@ -1,363 +1,79 @@
-use meilisearch_types::Document;
-use serde_json::json;
-
-use crate::search::insert_geo_distance;
-
-#[test]
-fn test_insert_geo_distance() {
-    let value: Document = serde_json::from_str(
-        r#"{
-          "_geo": {
-            "lat": 50.629973371633746,
-            "lng": 3.0569447399419567
-          },
-          "city": "Lille",
-          "id": "1"
-        }"#,
-    )
-    .unwrap();
-
-    let sorters = &["_geoPoint(50.629973371633746,3.0569447399419567):desc".to_string()];
-    let mut document = value.clone();
-    insert_geo_distance(sorters, &mut document);
-    assert_eq!(document.get("_geoDistance"), Some(&json!(0)));
-
-    let sorters = &["_geoPoint(50.629973371633746, 3.0569447399419567):asc".to_string()];
-    let mut document = value.clone();
-    insert_geo_distance(sorters, &mut document);
-    assert_eq!(document.get("_geoDistance"), Some(&json!(0)));
-
-    let sorters = &["_geoPoint(   50.629973371633746   ,  3.0569447399419567   ):desc".to_string()];
-    let mut document = value.clone();
-    insert_geo_distance(sorters, &mut document);
-    assert_eq!(document.get("_geoDistance"), Some(&json!(0)));
-
-    let sorters = &[
-        "prix:asc",
-        "villeneuve:desc",
-        "_geoPoint(50.629973371633746, 3.0569447399419567):asc",
-        "ubu:asc",
-    ]
-    .map(|s| s.to_string());
-    let mut document = value.clone();
-    insert_geo_distance(sorters, &mut document);
-    assert_eq!(document.get("_geoDistance"), Some(&json!(0)));
-
-    // only the first geoPoint is used to compute the distance
-    let sorters = &[
-        "chien:desc",
-        "_geoPoint(50.629973371633746, 3.0569447399419567):asc",
-        "pangolin:desc",
-        "_geoPoint(100.0, -80.0):asc",
-        "chat:asc",
-    ]
-    .map(|s| s.to_string());
-    let mut document = value.clone();
-    insert_geo_distance(sorters, &mut document);
-    assert_eq!(document.get("_geoDistance"), Some(&json!(0)));
-
-    // there was no _geoPoint so nothing is inserted in the document
-    let sorters = &["chien:asc".to_string()];
-    let mut document = value;
-    insert_geo_distance(sorters, &mut document);
-    assert_eq!(document.get("_geoDistance"), None);
-}
-
-#[test]
-fn test_insert_geo_distance_with_coords_as_string() {
-    let value: Document = serde_json::from_str(
-        r#"{
-          "_geo": {
-            "lat": "50",
-            "lng": 3
-          }
-        }"#,
-    )
-    .unwrap();
-
-    let sorters = &["_geoPoint(50,3):desc".to_string()];
-    let mut document = value.clone();
-    insert_geo_distance(sorters, &mut document);
-    assert_eq!(document.get("_geoDistance"), Some(&json!(0)));
-
-    let value: Document = serde_json::from_str(
-        r#"{
-          "_geo": {
-            "lat": "50",
-            "lng": "3"
-          },
-          "id": "1"
-        }"#,
-    )
-    .unwrap();
-
-    let sorters = &["_geoPoint(50,3):desc".to_string()];
-    let mut document = value.clone();
-    insert_geo_distance(sorters, &mut document);
-    assert_eq!(document.get("_geoDistance"), Some(&json!(0)));
-
-    let value: Document = serde_json::from_str(
-        r#"{
-          "_geo": {
-            "lat": 50,
-            "lng": "3"
-          },
-          "id": "1"
-        }"#,
-    )
-    .unwrap();
-
-    let sorters = &["_geoPoint(50,3):desc".to_string()];
-    let mut document = value.clone();
-    insert_geo_distance(sorters, &mut document);
-    assert_eq!(document.get("_geoDistance"), Some(&json!(0)));
-}
-
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::search::{SearchTiming, SearchTimingHierarchy};
-    use std::collections::BTreeMap;
     use std::time::Duration;
 
     #[test]
     fn test_search_timing_hierarchy() {
-        // Create a sample SearchTiming with some data
-        let mut timing = SearchTiming {
-            total_search_time: Duration::from_millis(100),
-            query_processing_time: Duration::from_millis(20),
-            search_execution_time: Duration::from_millis(50),
-            result_formatting_time: Duration::from_millis(30),
-            query_parsing_time: Duration::from_millis(10),
-            query_tree_build_time: Duration::from_millis(5),
-            query_tree_simplify_time: Duration::from_millis(5),
-            ranking_graph_build_time: Duration::from_millis(0),
-            tokenization_time: Duration::from_millis(15),
-            tokenizer_build_time: Duration::from_millis(5),
-            keyword_search_time: Duration::from_millis(25),
-            vector_search_time: Duration::from_millis(0),
-            hybrid_search_time: Duration::from_millis(0),
-            embedding_time: Duration::from_millis(0),
-            words_ranking_time: Duration::from_millis(10),
-            typo_ranking_time: Duration::from_millis(5),
-            proximity_ranking_time: Duration::from_millis(5),
-            attribute_ranking_time: Duration::from_millis(5),
-            exactness_ranking_time: Duration::from_millis(0),
-            sort_ranking_time: Duration::from_millis(0),
-            geo_sort_time: Duration::from_millis(0),
-            geo_filter_time: Duration::from_millis(0),
-            geo_sort_compute_time: Duration::from_millis(0),
-            geo_bucket_sort_time: Duration::from_millis(0),
-            facet_distribution_time: Duration::from_millis(10),
-            facet_stats_time: Duration::from_millis(5),
-            facet_search_time: Duration::from_millis(0),
-            result_sorting_time: Duration::from_millis(15),
-            distinct_processing_time: Duration::from_millis(10),
-            pagination_time: Duration::from_millis(5),
-            cache_lookup_time: Duration::from_millis(5),
-            database_read_time: Duration::from_millis(20),
-            filter_application_time: Duration::from_millis(10),
-            facet_attribute_timing: BTreeMap::new(),
-            filter_attribute_timing: BTreeMap::new(),
-            additional_timing: BTreeMap::new(),
-        };
+        let mut timing = SearchTiming::default();
+        timing.total_search_time = Duration::from_millis(100);
+        timing.query_processing_time = Duration::from_millis(30);
+        timing.query_parsing_time = Duration::from_millis(10);
+        timing.tokenization_time = Duration::from_millis(20);
+        timing.search_execution_time = Duration::from_millis(40);
+        timing.result_formatting_time = Duration::from_millis(10);
 
-        // Add some per-attribute timing
-        timing.facet_attribute_timing.insert("category".to_string(), Duration::from_millis(8));
-        timing.facet_attribute_timing.insert("brand".to_string(), Duration::from_millis(7));
-
-        // Convert to hierarchical format
         let hierarchy = SearchTimingHierarchy::from_flat_timing(&timing);
+
+        // Check that hierarchical entries exist
+        assert!(hierarchy.timing_entries.contains_key("total_search"));
+        assert!(hierarchy.timing_entries.contains_key("query_processing"));
+        assert!(hierarchy.timing_entries.contains_key("query_processing > parsing"));
+        assert!(hierarchy.timing_entries.contains_key("tokenization"));
+        assert!(hierarchy.timing_entries.contains_key("search_execution"));
+        assert!(hierarchy.timing_entries.contains_key("result_formatting"));
+
+        // Check values (they're now JSON values, so we need to extract them)
+        let total_search = hierarchy.timing_entries.get("total_search").unwrap();
+        assert_eq!(total_search.as_str().unwrap(), "100.00ms");
+
+        let query_processing = hierarchy.timing_entries.get("query_processing").unwrap();
+        assert_eq!(query_processing.as_str().unwrap(), "30.00ms");
+
+        let query_parsing = hierarchy.timing_entries.get("query_processing > parsing").unwrap();
+        assert_eq!(query_parsing.as_str().unwrap(), "10.00ms");
+    }
+
+    #[test]
+    fn test_search_timing_hierarchy_empty() {
+        let timing = SearchTiming::default();
+        let hierarchy = SearchTimingHierarchy::from_flat_timing(&timing);
+
+        // Only total_search should be present with zero duration
+        assert_eq!(hierarchy.timing_entries.len(), 1);
+        assert!(hierarchy.timing_entries.contains_key("total_search"));
+        
+        let total_search = hierarchy.timing_entries.get("total_search").unwrap();
+        assert_eq!(total_search.as_str().unwrap(), "0.00ns");
+    }
+
+    #[test]
+    fn test_search_timing_hierarchy_display() {
+        let mut timing = SearchTiming::default();
+        timing.total_search_time = Duration::from_millis(150);
+        timing.query_processing_time = Duration::from_millis(50);
+        timing.query_parsing_time = Duration::from_millis(20);
+        timing.query_tree_build_time = Duration::from_millis(30);
+        timing.tokenization_time = Duration::from_millis(25);
+        timing.search_execution_time = Duration::from_millis(60);
+        timing.keyword_search_time = Duration::from_millis(40);
+        timing.vector_search_time = Duration::from_millis(20);
+        timing.result_formatting_time = Duration::from_millis(15);
+
+        let hierarchy = SearchTimingHierarchy::from_flat_timing(&timing);
+
+        println!("Search Timing Hierarchy:");
+        for (key, value) in &hierarchy.timing_entries {
+            println!("  {}: {}", key, value);
+        }
 
         // Verify the hierarchical structure
         assert!(hierarchy.timing_entries.contains_key("total_search"));
         assert!(hierarchy.timing_entries.contains_key("query_processing"));
         assert!(hierarchy.timing_entries.contains_key("query_processing > parsing"));
         assert!(hierarchy.timing_entries.contains_key("query_processing > tree_build"));
-        assert!(hierarchy.timing_entries.contains_key("query_processing > tree_simplify"));
-        assert!(hierarchy.timing_entries.contains_key("tokenization"));
-        assert!(hierarchy.timing_entries.contains_key("tokenization > tokenizer_build"));
         assert!(hierarchy.timing_entries.contains_key("search_execution"));
         assert!(hierarchy.timing_entries.contains_key("search_execution > keyword_search"));
-        assert!(hierarchy.timing_entries.contains_key("search_execution > ranking > words"));
-        assert!(hierarchy.timing_entries.contains_key("search_execution > ranking > typo"));
-        assert!(hierarchy.timing_entries.contains_key("search_execution > ranking > proximity"));
-        assert!(hierarchy.timing_entries.contains_key("search_execution > ranking > attribute"));
-        assert!(hierarchy.timing_entries.contains_key("search_execution > cache > lookup"));
-        assert!(hierarchy.timing_entries.contains_key("search_execution > database > read"));
-        assert!(hierarchy.timing_entries.contains_key("search_execution > database > filter"));
-        assert!(hierarchy.timing_entries.contains_key("result_formatting"));
-        assert!(hierarchy.timing_entries.contains_key("result_formatting > sorting"));
-        assert!(hierarchy.timing_entries.contains_key("result_formatting > distinct"));
-        assert!(hierarchy.timing_entries.contains_key("result_formatting > pagination"));
-        assert!(hierarchy.timing_entries.contains_key("facets"));
-        assert!(hierarchy.timing_entries.contains_key("facets > distribution"));
-        assert!(hierarchy.timing_entries.contains_key("facets > stats"));
-        assert!(hierarchy.timing_entries.contains_key("facets > attribute > category"));
-        assert!(hierarchy.timing_entries.contains_key("facets > attribute > brand"));
-
-        // Verify timing values
-        assert_eq!(hierarchy.timing_entries["total_search"], Duration::from_millis(100));
-        assert_eq!(hierarchy.timing_entries["query_processing"], Duration::from_millis(20));
-        assert_eq!(hierarchy.timing_entries["query_processing > parsing"], Duration::from_millis(10));
-        assert_eq!(hierarchy.timing_entries["search_execution"], Duration::from_millis(50));
-        assert_eq!(hierarchy.timing_entries["result_formatting"], Duration::from_millis(30));
-        assert_eq!(hierarchy.timing_entries["facets"], Duration::from_millis(15)); // 10 + 5 + 0
-        assert_eq!(hierarchy.timing_entries["facets > attribute > category"], Duration::from_millis(8));
-        assert_eq!(hierarchy.timing_entries["facets > attribute > brand"], Duration::from_millis(7));
-
-        // Verify that zero-duration entries are not included
-        assert!(!hierarchy.timing_entries.contains_key("query_processing > ranking_graph_build"));
-        assert!(!hierarchy.timing_entries.contains_key("search_execution > vector_search"));
-        assert!(!hierarchy.timing_entries.contains_key("search_execution > hybrid_search"));
-    }
-
-    #[test]
-    fn test_search_timing_hierarchy_empty() {
-        // Create an empty SearchTiming
-        let timing = SearchTiming {
-            total_search_time: Duration::ZERO,
-            query_processing_time: Duration::ZERO,
-            search_execution_time: Duration::ZERO,
-            result_formatting_time: Duration::ZERO,
-            query_parsing_time: Duration::ZERO,
-            query_tree_build_time: Duration::ZERO,
-            query_tree_simplify_time: Duration::ZERO,
-            ranking_graph_build_time: Duration::ZERO,
-            tokenization_time: Duration::ZERO,
-            tokenizer_build_time: Duration::ZERO,
-            keyword_search_time: Duration::ZERO,
-            vector_search_time: Duration::ZERO,
-            hybrid_search_time: Duration::ZERO,
-            embedding_time: Duration::ZERO,
-            words_ranking_time: Duration::ZERO,
-            typo_ranking_time: Duration::ZERO,
-            proximity_ranking_time: Duration::ZERO,
-            attribute_ranking_time: Duration::ZERO,
-            exactness_ranking_time: Duration::ZERO,
-            sort_ranking_time: Duration::ZERO,
-            geo_sort_time: Duration::ZERO,
-            geo_filter_time: Duration::ZERO,
-            geo_sort_compute_time: Duration::ZERO,
-            geo_bucket_sort_time: Duration::ZERO,
-            facet_distribution_time: Duration::ZERO,
-            facet_stats_time: Duration::ZERO,
-            facet_search_time: Duration::ZERO,
-            result_sorting_time: Duration::ZERO,
-            distinct_processing_time: Duration::ZERO,
-            pagination_time: Duration::ZERO,
-            cache_lookup_time: Duration::ZERO,
-            database_read_time: Duration::ZERO,
-            filter_application_time: Duration::ZERO,
-            facet_attribute_timing: BTreeMap::new(),
-            filter_attribute_timing: BTreeMap::new(),
-            additional_timing: BTreeMap::new(),
-        };
-
-        // Convert to hierarchical format
-        let hierarchy = SearchTimingHierarchy::from_flat_timing(&timing);
-
-        // Should only contain total_search with zero duration
-        assert_eq!(hierarchy.timing_entries.len(), 1);
-        assert!(hierarchy.timing_entries.contains_key("total_search"));
-        assert_eq!(hierarchy.timing_entries["total_search"], Duration::ZERO);
-    }
-
-    #[test]
-    fn test_search_timing_hierarchy_display() {
-        // Create a sample SearchTiming with some data
-        let mut timing = SearchTiming {
-            total_search_time: Duration::from_millis(150),
-            query_processing_time: Duration::from_millis(30),
-            search_execution_time: Duration::from_millis(80),
-            result_formatting_time: Duration::from_millis(40),
-            query_parsing_time: Duration::from_millis(15),
-            query_tree_build_time: Duration::from_millis(10),
-            query_tree_simplify_time: Duration::from_millis(5),
-            ranking_graph_build_time: Duration::from_millis(0),
-            tokenization_time: Duration::from_millis(20),
-            tokenizer_build_time: Duration::from_millis(8),
-            keyword_search_time: Duration::from_millis(35),
-            vector_search_time: Duration::from_millis(0),
-            hybrid_search_time: Duration::from_millis(0),
-            embedding_time: Duration::from_millis(0),
-            words_ranking_time: Duration::from_millis(15),
-            typo_ranking_time: Duration::from_millis(8),
-            proximity_ranking_time: Duration::from_millis(7),
-            attribute_ranking_time: Duration::from_millis(10),
-            exactness_ranking_time: Duration::from_millis(0),
-            sort_ranking_time: Duration::from_millis(0),
-            geo_sort_time: Duration::from_millis(0),
-            geo_filter_time: Duration::from_millis(0),
-            geo_sort_compute_time: Duration::from_millis(0),
-            geo_bucket_sort_time: Duration::from_millis(0),
-            facet_distribution_time: Duration::from_millis(12),
-            facet_stats_time: Duration::from_millis(6),
-            facet_search_time: Duration::from_millis(0),
-            result_sorting_time: Duration::from_millis(20),
-            distinct_processing_time: Duration::from_millis(12),
-            pagination_time: Duration::from_millis(8),
-            cache_lookup_time: Duration::from_millis(8),
-            database_read_time: Duration::from_millis(25),
-            filter_application_time: Duration::from_millis(12),
-            facet_attribute_timing: BTreeMap::new(),
-            filter_attribute_timing: BTreeMap::new(),
-            additional_timing: BTreeMap::new(),
-        };
-
-        // Add some per-attribute timing
-        timing.facet_attribute_timing.insert("category".to_string(), Duration::from_millis(10));
-        timing.facet_attribute_timing.insert("brand".to_string(), Duration::from_millis(8));
-
-        // Convert to hierarchical format
-        let hierarchy = SearchTimingHierarchy::from_flat_timing(&timing);
-
-        // Print the hierarchical structure for demonstration
-        println!("\n=== Search Timing Hierarchy ===");
-        for (key, duration) in &hierarchy.timing_entries {
-            let indent = key.matches('>').count() * 2;
-            let indent_str = " ".repeat(indent);
-            println!("{}{}: {:?}", indent_str, key, duration);
-        }
-        println!("===============================\n");
-
-        // Verify the structure is correct
-        assert_eq!(hierarchy.timing_entries["total_search"], Duration::from_millis(150));
-        assert_eq!(hierarchy.timing_entries["query_processing"], Duration::from_millis(30));
-        assert_eq!(hierarchy.timing_entries["query_processing > parsing"], Duration::from_millis(15));
-        assert_eq!(hierarchy.timing_entries["query_processing > tree_build"], Duration::from_millis(10));
-        assert_eq!(hierarchy.timing_entries["query_processing > tree_simplify"], Duration::from_millis(5));
-        assert_eq!(hierarchy.timing_entries["tokenization"], Duration::from_millis(20));
-        assert_eq!(hierarchy.timing_entries["tokenization > tokenizer_build"], Duration::from_millis(8));
-        assert_eq!(hierarchy.timing_entries["search_execution"], Duration::from_millis(80));
-        assert_eq!(hierarchy.timing_entries["search_execution > keyword_search"], Duration::from_millis(35));
-        assert_eq!(hierarchy.timing_entries["search_execution > ranking > words"], Duration::from_millis(15));
-        assert_eq!(hierarchy.timing_entries["search_execution > ranking > typo"], Duration::from_millis(8));
-        assert_eq!(hierarchy.timing_entries["search_execution > ranking > proximity"], Duration::from_millis(7));
-        assert_eq!(hierarchy.timing_entries["search_execution > ranking > attribute"], Duration::from_millis(10));
-        assert_eq!(hierarchy.timing_entries["search_execution > cache > lookup"], Duration::from_millis(8));
-        assert_eq!(hierarchy.timing_entries["search_execution > database > read"], Duration::from_millis(25));
-        assert_eq!(hierarchy.timing_entries["search_execution > database > filter"], Duration::from_millis(12));
-        assert_eq!(hierarchy.timing_entries["result_formatting"], Duration::from_millis(40));
-        assert_eq!(hierarchy.timing_entries["result_formatting > sorting"], Duration::from_millis(20));
-        assert_eq!(hierarchy.timing_entries["result_formatting > distinct"], Duration::from_millis(12));
-        assert_eq!(hierarchy.timing_entries["result_formatting > pagination"], Duration::from_millis(8));
-        assert_eq!(hierarchy.timing_entries["facets"], Duration::from_millis(18)); // 12 + 6 + 0
-        assert_eq!(hierarchy.timing_entries["facets > distribution"], Duration::from_millis(12));
-        assert_eq!(hierarchy.timing_entries["facets > stats"], Duration::from_millis(6));
-        assert_eq!(hierarchy.timing_entries["facets > attribute > category"], Duration::from_millis(10));
-        assert_eq!(hierarchy.timing_entries["facets > attribute > brand"], Duration::from_millis(8));
-
-        // Verify that zero-duration entries are not included
-        assert!(!hierarchy.timing_entries.contains_key("query_processing > ranking_graph_build"));
-        assert!(!hierarchy.timing_entries.contains_key("search_execution > vector_search"));
-        assert!(!hierarchy.timing_entries.contains_key("search_execution > hybrid_search"));
-        assert!(!hierarchy.timing_entries.contains_key("search_execution > ranking > exactness"));
-        assert!(!hierarchy.timing_entries.contains_key("search_execution > ranking > sort"));
-        assert!(!hierarchy.timing_entries.contains_key("search_execution > geo > sort"));
-        assert!(!hierarchy.timing_entries.contains_key("search_execution > geo > filter"));
-        assert!(!hierarchy.timing_entries.contains_key("search_execution > geo > sort > compute"));
-        assert!(!hierarchy.timing_entries.contains_key("search_execution > geo > sort > bucket"));
-        assert!(!hierarchy.timing_entries.contains_key("facets > search"));
+        assert!(hierarchy.timing_entries.contains_key("search_execution > vector_search"));
     }
 }

--- a/crates/meilisearch/src/search/mod_test.rs
+++ b/crates/meilisearch/src/search/mod_test.rs
@@ -16,7 +16,7 @@ mod tests {
         let hierarchy = SearchTimingHierarchy::from_flat_timing(&timing);
 
         // Check that hierarchical entries exist
-        assert!(hierarchy.timing_entries.contains_key("total_search"));
+        assert!(hierarchy.timing_entries.contains_key("processing_time_ms"));
         assert!(hierarchy.timing_entries.contains_key("query_processing"));
         assert!(hierarchy.timing_entries.contains_key("query_processing > parsing"));
         assert!(hierarchy.timing_entries.contains_key("tokenization"));
@@ -24,8 +24,8 @@ mod tests {
         assert!(hierarchy.timing_entries.contains_key("result_formatting"));
 
         // Check values (they're now JSON values, so we need to extract them)
-        let total_search = hierarchy.timing_entries.get("total_search").unwrap();
-        assert_eq!(total_search.as_str().unwrap(), "100.00ms");
+        let processing_time_ms = hierarchy.timing_entries.get("processing_time_ms").unwrap();
+        assert_eq!(processing_time_ms.as_str().unwrap(), "100.00ms");
 
         let query_processing = hierarchy.timing_entries.get("query_processing").unwrap();
         assert_eq!(query_processing.as_str().unwrap(), "30.00ms");
@@ -39,12 +39,12 @@ mod tests {
         let timing = SearchTiming::default();
         let hierarchy = SearchTimingHierarchy::from_flat_timing(&timing);
 
-        // Only total_search should be present with zero duration
+        // Only processing_time_ms should be present with zero duration
         assert_eq!(hierarchy.timing_entries.len(), 1);
-        assert!(hierarchy.timing_entries.contains_key("total_search"));
+        assert!(hierarchy.timing_entries.contains_key("processing_time_ms"));
         
-        let total_search = hierarchy.timing_entries.get("total_search").unwrap();
-        assert_eq!(total_search.as_str().unwrap(), "0.00ns");
+        let processing_time_ms = hierarchy.timing_entries.get("processing_time_ms").unwrap();
+        assert_eq!(processing_time_ms.as_str().unwrap(), "0.00ns");
     }
 
     #[test]
@@ -68,7 +68,7 @@ mod tests {
         }
 
         // Verify the hierarchical structure
-        assert!(hierarchy.timing_entries.contains_key("total_search"));
+        assert!(hierarchy.timing_entries.contains_key("processing_time_ms"));
         assert!(hierarchy.timing_entries.contains_key("query_processing"));
         assert!(hierarchy.timing_entries.contains_key("query_processing > parsing"));
         assert!(hierarchy.timing_entries.contains_key("query_processing > tree_build"));

--- a/crates/meilisearch/src/search/mod_test.rs
+++ b/crates/meilisearch/src/search/mod_test.rs
@@ -112,3 +112,252 @@ fn test_insert_geo_distance_with_coords_as_string() {
     insert_geo_distance(sorters, &mut document);
     assert_eq!(document.get("_geoDistance"), Some(&json!(0)));
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::search::{SearchTiming, SearchTimingHierarchy};
+    use std::collections::BTreeMap;
+    use std::time::Duration;
+
+    #[test]
+    fn test_search_timing_hierarchy() {
+        // Create a sample SearchTiming with some data
+        let mut timing = SearchTiming {
+            total_search_time: Duration::from_millis(100),
+            query_processing_time: Duration::from_millis(20),
+            search_execution_time: Duration::from_millis(50),
+            result_formatting_time: Duration::from_millis(30),
+            query_parsing_time: Duration::from_millis(10),
+            query_tree_build_time: Duration::from_millis(5),
+            query_tree_simplify_time: Duration::from_millis(5),
+            ranking_graph_build_time: Duration::from_millis(0),
+            tokenization_time: Duration::from_millis(15),
+            tokenizer_build_time: Duration::from_millis(5),
+            keyword_search_time: Duration::from_millis(25),
+            vector_search_time: Duration::from_millis(0),
+            hybrid_search_time: Duration::from_millis(0),
+            embedding_time: Duration::from_millis(0),
+            words_ranking_time: Duration::from_millis(10),
+            typo_ranking_time: Duration::from_millis(5),
+            proximity_ranking_time: Duration::from_millis(5),
+            attribute_ranking_time: Duration::from_millis(5),
+            exactness_ranking_time: Duration::from_millis(0),
+            sort_ranking_time: Duration::from_millis(0),
+            geo_sort_time: Duration::from_millis(0),
+            geo_filter_time: Duration::from_millis(0),
+            geo_sort_compute_time: Duration::from_millis(0),
+            geo_bucket_sort_time: Duration::from_millis(0),
+            facet_distribution_time: Duration::from_millis(10),
+            facet_stats_time: Duration::from_millis(5),
+            facet_search_time: Duration::from_millis(0),
+            result_sorting_time: Duration::from_millis(15),
+            distinct_processing_time: Duration::from_millis(10),
+            pagination_time: Duration::from_millis(5),
+            cache_lookup_time: Duration::from_millis(5),
+            database_read_time: Duration::from_millis(20),
+            filter_application_time: Duration::from_millis(10),
+            facet_attribute_timing: BTreeMap::new(),
+            filter_attribute_timing: BTreeMap::new(),
+            additional_timing: BTreeMap::new(),
+        };
+
+        // Add some per-attribute timing
+        timing.facet_attribute_timing.insert("category".to_string(), Duration::from_millis(8));
+        timing.facet_attribute_timing.insert("brand".to_string(), Duration::from_millis(7));
+
+        // Convert to hierarchical format
+        let hierarchy = SearchTimingHierarchy::from_flat_timing(&timing);
+
+        // Verify the hierarchical structure
+        assert!(hierarchy.timing_entries.contains_key("total_search"));
+        assert!(hierarchy.timing_entries.contains_key("query_processing"));
+        assert!(hierarchy.timing_entries.contains_key("query_processing > parsing"));
+        assert!(hierarchy.timing_entries.contains_key("query_processing > tree_build"));
+        assert!(hierarchy.timing_entries.contains_key("query_processing > tree_simplify"));
+        assert!(hierarchy.timing_entries.contains_key("tokenization"));
+        assert!(hierarchy.timing_entries.contains_key("tokenization > tokenizer_build"));
+        assert!(hierarchy.timing_entries.contains_key("search_execution"));
+        assert!(hierarchy.timing_entries.contains_key("search_execution > keyword_search"));
+        assert!(hierarchy.timing_entries.contains_key("search_execution > ranking > words"));
+        assert!(hierarchy.timing_entries.contains_key("search_execution > ranking > typo"));
+        assert!(hierarchy.timing_entries.contains_key("search_execution > ranking > proximity"));
+        assert!(hierarchy.timing_entries.contains_key("search_execution > ranking > attribute"));
+        assert!(hierarchy.timing_entries.contains_key("search_execution > cache > lookup"));
+        assert!(hierarchy.timing_entries.contains_key("search_execution > database > read"));
+        assert!(hierarchy.timing_entries.contains_key("search_execution > database > filter"));
+        assert!(hierarchy.timing_entries.contains_key("result_formatting"));
+        assert!(hierarchy.timing_entries.contains_key("result_formatting > sorting"));
+        assert!(hierarchy.timing_entries.contains_key("result_formatting > distinct"));
+        assert!(hierarchy.timing_entries.contains_key("result_formatting > pagination"));
+        assert!(hierarchy.timing_entries.contains_key("facets"));
+        assert!(hierarchy.timing_entries.contains_key("facets > distribution"));
+        assert!(hierarchy.timing_entries.contains_key("facets > stats"));
+        assert!(hierarchy.timing_entries.contains_key("facets > attribute > category"));
+        assert!(hierarchy.timing_entries.contains_key("facets > attribute > brand"));
+
+        // Verify timing values
+        assert_eq!(hierarchy.timing_entries["total_search"], Duration::from_millis(100));
+        assert_eq!(hierarchy.timing_entries["query_processing"], Duration::from_millis(20));
+        assert_eq!(hierarchy.timing_entries["query_processing > parsing"], Duration::from_millis(10));
+        assert_eq!(hierarchy.timing_entries["search_execution"], Duration::from_millis(50));
+        assert_eq!(hierarchy.timing_entries["result_formatting"], Duration::from_millis(30));
+        assert_eq!(hierarchy.timing_entries["facets"], Duration::from_millis(15)); // 10 + 5 + 0
+        assert_eq!(hierarchy.timing_entries["facets > attribute > category"], Duration::from_millis(8));
+        assert_eq!(hierarchy.timing_entries["facets > attribute > brand"], Duration::from_millis(7));
+
+        // Verify that zero-duration entries are not included
+        assert!(!hierarchy.timing_entries.contains_key("query_processing > ranking_graph_build"));
+        assert!(!hierarchy.timing_entries.contains_key("search_execution > vector_search"));
+        assert!(!hierarchy.timing_entries.contains_key("search_execution > hybrid_search"));
+    }
+
+    #[test]
+    fn test_search_timing_hierarchy_empty() {
+        // Create an empty SearchTiming
+        let timing = SearchTiming {
+            total_search_time: Duration::ZERO,
+            query_processing_time: Duration::ZERO,
+            search_execution_time: Duration::ZERO,
+            result_formatting_time: Duration::ZERO,
+            query_parsing_time: Duration::ZERO,
+            query_tree_build_time: Duration::ZERO,
+            query_tree_simplify_time: Duration::ZERO,
+            ranking_graph_build_time: Duration::ZERO,
+            tokenization_time: Duration::ZERO,
+            tokenizer_build_time: Duration::ZERO,
+            keyword_search_time: Duration::ZERO,
+            vector_search_time: Duration::ZERO,
+            hybrid_search_time: Duration::ZERO,
+            embedding_time: Duration::ZERO,
+            words_ranking_time: Duration::ZERO,
+            typo_ranking_time: Duration::ZERO,
+            proximity_ranking_time: Duration::ZERO,
+            attribute_ranking_time: Duration::ZERO,
+            exactness_ranking_time: Duration::ZERO,
+            sort_ranking_time: Duration::ZERO,
+            geo_sort_time: Duration::ZERO,
+            geo_filter_time: Duration::ZERO,
+            geo_sort_compute_time: Duration::ZERO,
+            geo_bucket_sort_time: Duration::ZERO,
+            facet_distribution_time: Duration::ZERO,
+            facet_stats_time: Duration::ZERO,
+            facet_search_time: Duration::ZERO,
+            result_sorting_time: Duration::ZERO,
+            distinct_processing_time: Duration::ZERO,
+            pagination_time: Duration::ZERO,
+            cache_lookup_time: Duration::ZERO,
+            database_read_time: Duration::ZERO,
+            filter_application_time: Duration::ZERO,
+            facet_attribute_timing: BTreeMap::new(),
+            filter_attribute_timing: BTreeMap::new(),
+            additional_timing: BTreeMap::new(),
+        };
+
+        // Convert to hierarchical format
+        let hierarchy = SearchTimingHierarchy::from_flat_timing(&timing);
+
+        // Should only contain total_search with zero duration
+        assert_eq!(hierarchy.timing_entries.len(), 1);
+        assert!(hierarchy.timing_entries.contains_key("total_search"));
+        assert_eq!(hierarchy.timing_entries["total_search"], Duration::ZERO);
+    }
+
+    #[test]
+    fn test_search_timing_hierarchy_display() {
+        // Create a sample SearchTiming with some data
+        let mut timing = SearchTiming {
+            total_search_time: Duration::from_millis(150),
+            query_processing_time: Duration::from_millis(30),
+            search_execution_time: Duration::from_millis(80),
+            result_formatting_time: Duration::from_millis(40),
+            query_parsing_time: Duration::from_millis(15),
+            query_tree_build_time: Duration::from_millis(10),
+            query_tree_simplify_time: Duration::from_millis(5),
+            ranking_graph_build_time: Duration::from_millis(0),
+            tokenization_time: Duration::from_millis(20),
+            tokenizer_build_time: Duration::from_millis(8),
+            keyword_search_time: Duration::from_millis(35),
+            vector_search_time: Duration::from_millis(0),
+            hybrid_search_time: Duration::from_millis(0),
+            embedding_time: Duration::from_millis(0),
+            words_ranking_time: Duration::from_millis(15),
+            typo_ranking_time: Duration::from_millis(8),
+            proximity_ranking_time: Duration::from_millis(7),
+            attribute_ranking_time: Duration::from_millis(10),
+            exactness_ranking_time: Duration::from_millis(0),
+            sort_ranking_time: Duration::from_millis(0),
+            geo_sort_time: Duration::from_millis(0),
+            geo_filter_time: Duration::from_millis(0),
+            geo_sort_compute_time: Duration::from_millis(0),
+            geo_bucket_sort_time: Duration::from_millis(0),
+            facet_distribution_time: Duration::from_millis(12),
+            facet_stats_time: Duration::from_millis(6),
+            facet_search_time: Duration::from_millis(0),
+            result_sorting_time: Duration::from_millis(20),
+            distinct_processing_time: Duration::from_millis(12),
+            pagination_time: Duration::from_millis(8),
+            cache_lookup_time: Duration::from_millis(8),
+            database_read_time: Duration::from_millis(25),
+            filter_application_time: Duration::from_millis(12),
+            facet_attribute_timing: BTreeMap::new(),
+            filter_attribute_timing: BTreeMap::new(),
+            additional_timing: BTreeMap::new(),
+        };
+
+        // Add some per-attribute timing
+        timing.facet_attribute_timing.insert("category".to_string(), Duration::from_millis(10));
+        timing.facet_attribute_timing.insert("brand".to_string(), Duration::from_millis(8));
+
+        // Convert to hierarchical format
+        let hierarchy = SearchTimingHierarchy::from_flat_timing(&timing);
+
+        // Print the hierarchical structure for demonstration
+        println!("\n=== Search Timing Hierarchy ===");
+        for (key, duration) in &hierarchy.timing_entries {
+            let indent = key.matches('>').count() * 2;
+            let indent_str = " ".repeat(indent);
+            println!("{}{}: {:?}", indent_str, key, duration);
+        }
+        println!("===============================\n");
+
+        // Verify the structure is correct
+        assert_eq!(hierarchy.timing_entries["total_search"], Duration::from_millis(150));
+        assert_eq!(hierarchy.timing_entries["query_processing"], Duration::from_millis(30));
+        assert_eq!(hierarchy.timing_entries["query_processing > parsing"], Duration::from_millis(15));
+        assert_eq!(hierarchy.timing_entries["query_processing > tree_build"], Duration::from_millis(10));
+        assert_eq!(hierarchy.timing_entries["query_processing > tree_simplify"], Duration::from_millis(5));
+        assert_eq!(hierarchy.timing_entries["tokenization"], Duration::from_millis(20));
+        assert_eq!(hierarchy.timing_entries["tokenization > tokenizer_build"], Duration::from_millis(8));
+        assert_eq!(hierarchy.timing_entries["search_execution"], Duration::from_millis(80));
+        assert_eq!(hierarchy.timing_entries["search_execution > keyword_search"], Duration::from_millis(35));
+        assert_eq!(hierarchy.timing_entries["search_execution > ranking > words"], Duration::from_millis(15));
+        assert_eq!(hierarchy.timing_entries["search_execution > ranking > typo"], Duration::from_millis(8));
+        assert_eq!(hierarchy.timing_entries["search_execution > ranking > proximity"], Duration::from_millis(7));
+        assert_eq!(hierarchy.timing_entries["search_execution > ranking > attribute"], Duration::from_millis(10));
+        assert_eq!(hierarchy.timing_entries["search_execution > cache > lookup"], Duration::from_millis(8));
+        assert_eq!(hierarchy.timing_entries["search_execution > database > read"], Duration::from_millis(25));
+        assert_eq!(hierarchy.timing_entries["search_execution > database > filter"], Duration::from_millis(12));
+        assert_eq!(hierarchy.timing_entries["result_formatting"], Duration::from_millis(40));
+        assert_eq!(hierarchy.timing_entries["result_formatting > sorting"], Duration::from_millis(20));
+        assert_eq!(hierarchy.timing_entries["result_formatting > distinct"], Duration::from_millis(12));
+        assert_eq!(hierarchy.timing_entries["result_formatting > pagination"], Duration::from_millis(8));
+        assert_eq!(hierarchy.timing_entries["facets"], Duration::from_millis(18)); // 12 + 6 + 0
+        assert_eq!(hierarchy.timing_entries["facets > distribution"], Duration::from_millis(12));
+        assert_eq!(hierarchy.timing_entries["facets > stats"], Duration::from_millis(6));
+        assert_eq!(hierarchy.timing_entries["facets > attribute > category"], Duration::from_millis(10));
+        assert_eq!(hierarchy.timing_entries["facets > attribute > brand"], Duration::from_millis(8));
+
+        // Verify that zero-duration entries are not included
+        assert!(!hierarchy.timing_entries.contains_key("query_processing > ranking_graph_build"));
+        assert!(!hierarchy.timing_entries.contains_key("search_execution > vector_search"));
+        assert!(!hierarchy.timing_entries.contains_key("search_execution > hybrid_search"));
+        assert!(!hierarchy.timing_entries.contains_key("search_execution > ranking > exactness"));
+        assert!(!hierarchy.timing_entries.contains_key("search_execution > ranking > sort"));
+        assert!(!hierarchy.timing_entries.contains_key("search_execution > geo > sort"));
+        assert!(!hierarchy.timing_entries.contains_key("search_execution > geo > filter"));
+        assert!(!hierarchy.timing_entries.contains_key("search_execution > geo > sort > compute"));
+        assert!(!hierarchy.timing_entries.contains_key("search_execution > geo > sort > bucket"));
+        assert!(!hierarchy.timing_entries.contains_key("facets > search"));
+    }
+}

--- a/crates/meilisearch/tests/search/mod.rs
+++ b/crates/meilisearch/tests/search/mod.rs
@@ -2127,3 +2127,42 @@ async fn simple_search_changing_unrelated_settings() {
         })
         .await;
 }
+
+#[actix_rt::test]
+async fn test_search_timing_structure() {
+    let server = Server::new_shared();
+    let index = server.unique_index();
+
+    let documents = DOCUMENTS.clone();
+    let (task, _status_code) = index.add_documents(documents, None).await;
+    server.wait_task(task.uid()).await.succeeded();
+
+    index
+        .search(json!({"q": "Dragon"}), |response, code| {
+            assert_eq!(code, 200, "{response}");
+            
+            // Check that detailed_timing is present
+            assert!(response.get("detailed_timing").is_some(), "detailed_timing field should be present");
+            
+            let detailed_timing = response.get("detailed_timing").unwrap();
+            assert!(detailed_timing.is_object(), "detailed_timing should be an object");
+            
+            // Check that processing_time_ms is present
+            assert!(detailed_timing.get("processing_time_ms").is_some(), "processing_time_ms should be present in detailed_timing");
+            
+            // Check that processing_time_ms is a string value
+            let processing_time = detailed_timing.get("processing_time_ms").unwrap();
+            assert!(processing_time.is_string(), "processing_time_ms should be a string");
+            
+            // Verify the timing value is in the expected format (e.g., "X.XXms")
+            let processing_time_str = processing_time.as_str().unwrap();
+            assert!(processing_time_str.ends_with("ms") || processing_time_str.ends_with("ns"), 
+                   "processing_time_ms should end with 'ms' or 'ns', got: {}", processing_time_str);
+            
+            // Check that hits are present
+            assert!(response.get("hits").is_some(), "hits field should be present");
+            let hits = response.get("hits").unwrap().as_array().unwrap();
+            assert_eq!(hits.len(), 1, "Should find 1 hit for 'Dragon'");
+        })
+        .await;
+}

--- a/crates/milli/src/search/facet/facet_distribution.rs
+++ b/crates/milli/src/search/facet/facet_distribution.rs
@@ -298,6 +298,9 @@ impl<'a> FacetDistribution<'a> {
         let filterable_attributes_rules = self.index.filterable_attributes_rules(self.rtxn)?;
         self.check_faceted_fields(&filterable_attributes_rules)?;
 
+        let span = tracing::trace_span!(target: "search::facets::stats", "facet_stats_computation");
+        let _enter = span.enter();
+        
         let mut distribution = BTreeMap::new();
         for (fid, name) in fields_ids_map.iter() {
             if self.select_field(name, &filterable_attributes_rules) {
@@ -334,6 +337,9 @@ impl<'a> FacetDistribution<'a> {
         let filterable_attributes_rules = self.index.filterable_attributes_rules(self.rtxn)?;
         self.check_faceted_fields(&filterable_attributes_rules)?;
 
+        let span = tracing::trace_span!(target: "search::facets::distribution", "facet_distribution_execution");
+        let _enter = span.enter();
+        
         let mut distribution = BTreeMap::new();
         for (fid, name) in fields_ids_map.iter() {
             if self.select_field(name, &filterable_attributes_rules) {

--- a/crates/milli/src/search/facet/filter.rs
+++ b/crates/milli/src/search/facet/filter.rs
@@ -253,6 +253,8 @@ impl<'a> Filter<'a> {
             }))?;
         }
 
+        let span = tracing::trace_span!(target: "search::geo::filter", "geo_filter_evaluation");
+        let _enter = span.enter();
         self.inner_evaluate(rtxn, index, &fields_ids_map, &filterable_attributes_rules, None)
     }
 

--- a/crates/milli/src/search/facet/search.rs
+++ b/crates/milli/src/search/facet/search.rs
@@ -99,6 +99,9 @@ impl<'a> SearchForFacetValues<'a> {
             .into());
         };
 
+        let span = tracing::trace_span!(target: "search::facets::search", "facet_search_execution");
+        let _enter = span.enter();
+        
         let fields_ids_map = index.fields_ids_map(rtxn)?;
         let Some(fid) = fields_ids_map.id(&self.facet) else {
             return Ok(Vec::new());

--- a/crates/milli/src/search/facet/search.rs
+++ b/crates/milli/src/search/facet/search.rs
@@ -260,7 +260,7 @@ impl<'a> SearchForFacetValues<'a> {
     }
 }
 
-#[derive(Debug, Clone, serde::Serialize, PartialEq)]
+#[derive(Debug, Clone, serde::Serialize, PartialEq, utoipa::ToSchema)]
 pub struct FacetValueHit {
     /// The original facet value
     pub value: String,

--- a/crates/milli/src/search/new/distinct.rs
+++ b/crates/milli/src/search/new/distinct.rs
@@ -27,6 +27,9 @@ pub fn apply_distinct_rule(
     field_id: u16,
     candidates: &RoaringBitmap,
 ) -> Result<DistinctOutput> {
+    let span = tracing::trace_span!(target: "search::results::distinct", "distinct_processing");
+    let _enter = span.enter();
+    
     let mut excluded = RoaringBitmap::new();
     let mut remaining = RoaringBitmap::new();
     for docid in candidates {

--- a/crates/milli/src/search/new/geo_sort.rs
+++ b/crates/milli/src/search/new/geo_sort.rs
@@ -154,6 +154,9 @@ impl<Q: RankingRuleQueryTrait> GeoSort<Q> {
 
         let cache_size = self.strategy.cache_size();
         if let Some(rtree) = rtree {
+            let compute_span = tracing::trace_span!(target: "search::geo::sort::compute", "geo_sort_compute");
+            let _compute_enter = compute_span.enter();
+            
             if self.ascending {
                 let point = lat_lng_to_xyz(&self.point);
                 for point in rtree.nearest_neighbor_iter(&point) {
@@ -179,6 +182,9 @@ impl<Q: RankingRuleQueryTrait> GeoSort<Q> {
             }
         } else {
             // the iterative version
+            let bucket_span = tracing::trace_span!(target: "search::geo::sort::bucket", "geo_sort_bucket");
+            let _bucket_enter = bucket_span.enter();
+            
             let [lat, lng] = self.field_ids.unwrap();
 
             let mut documents = geo_candidates

--- a/crates/milli/src/search/new/mod.rs
+++ b/crates/milli/src/search/new/mod.rs
@@ -813,6 +813,9 @@ pub fn execute_search(
         universe &=
             resolve_universe(ctx, &universe, &graph, terms_matching_strategy, query_graph_logger)?;
 
+        let span = tracing::trace_span!(target: "search::main", "search_execution");
+        let _entered = span.enter();
+        
         bucket_sort(
             ctx,
             ranking_rules,
@@ -829,6 +832,10 @@ pub fn execute_search(
     } else {
         let ranking_rules =
             get_ranking_rules_for_placeholder_search(ctx, sort_criteria, geo_param)?;
+        
+        let span = tracing::trace_span!(target: "search::main", "placeholder_search_execution");
+        let _entered = span.enter();
+        
         bucket_sort(
             ctx,
             ranking_rules,

--- a/crates/milli/src/search/new/query_graph.rs
+++ b/crates/milli/src/search/new/query_graph.rs
@@ -97,6 +97,9 @@ impl QueryGraph {
         // The terms here must be consecutive
         terms: &[LocatedQueryTerm],
     ) -> Result<(QueryGraph, Vec<LocatedQueryTerm>)> {
+        let span = tracing::trace_span!(target: "search::query::parse", "query_parsing");
+        let _entered = span.enter();
+        
         let mut new_located_query_terms = terms.to_vec();
 
         let nbr_typos = number_of_typos_allowed(ctx)?;
@@ -173,7 +176,12 @@ impl QueryGraph {
             node.data = node_data;
         }
         let mut graph = QueryGraph { root_node, end_node, nodes };
-        graph.build_initial_edges();
+        
+        {
+            let span = tracing::trace_span!(target: "search::query::tree_build", "query_tree_build");
+            let _entered = span.enter();
+            graph.build_initial_edges();
+        }
 
         Ok((graph, new_located_query_terms))
     }
@@ -224,6 +232,9 @@ impl QueryGraph {
     /// Simplify the query graph by removing all nodes that are disconnected from
     /// the start or end nodes.
     pub fn simplify(&mut self) {
+        let span = tracing::trace_span!(target: "search::query::simplify", "query_tree_simplify");
+        let _entered = span.enter();
+        
         loop {
             let mut nodes_to_remove = vec![];
             for (node_idx, node) in self.nodes.iter() {

--- a/crates/milli/src/search/new/ranking_rule_graph/build.rs
+++ b/crates/milli/src/search/new/ranking_rule_graph/build.rs
@@ -14,6 +14,9 @@ impl<G: RankingRuleGraphTrait> RankingRuleGraph<G> {
         query_graph: QueryGraph,
         cost_of_ignoring_node: MappedInterner<QueryNode, Option<(u32, SmallBitmap<QueryNode>)>>,
     ) -> Result<Self> {
+        let span = tracing::trace_span!(target: "search::graph_based", "ranking_graph_build");
+        let _entered = span.enter();
+        
         let QueryGraph { nodes: graph_nodes, .. } = &query_graph;
 
         let mut conditions_interner = DedupInterner::default();

--- a/crates/milli/src/vector/mod.rs
+++ b/crates/milli/src/vector/mod.rs
@@ -696,6 +696,10 @@ impl EmbeddingCache {
         if text.len() > Self::MAX_TEXT_LEN {
             return None;
         }
+        
+        let span = tracing::trace_span!(target: "search::cache::lookup", "cache_lookup");
+        let _enter = span.enter();
+        
         let mut cache = data.lock().unwrap();
 
         cache.get(text).cloned()


### PR DESCRIPTION
Adds detailed timing information to search responses to provide granular performance insights.

---
<a href="https://cursor.com/background-agent?bcId=bc-57085209-8b50-4abe-8941-07439bac7db9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-57085209-8b50-4abe-8941-07439bac7db9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

